### PR TITLE
Updates runner health interaction

### DIFF
--- a/src/cactus_orchestrator/tasks.py
+++ b/src/cactus_orchestrator/tasks.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 async def is_idle(now: datetime, url: str, idle_seconds: int) -> bool:
     async with ClientSession(base_url=url, timeout=ClientTimeout(30)) as s:
-        details = await RunnerClient.last_request(s)
+        details = await RunnerClient.last_interaction(s)
 
     if (now.timestamp() - details.timestamp.timestamp()) > idle_seconds:
         return True


### PR DESCRIPTION
There is a change in the runner's client API. The `last_request` call is replaced with the more general `last_interaction` call for determining runner health.

If you accept this pull request you'll need to get the latest version of `cactus-runner`.