### PR TITLE
Decouple UI from test defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "fastapi-async-sqlalchemy",
     "asyncpg",
     "cactus-test-definitions==1.11.1",
-    "cactus-schema==0.0.18",
+    "cactus-schema==0.0.19",
     "cactus-runner @ git+ssh://git@github.com/bsgip/cactus-runner.git@v1.8.0",
     "fastapi-pagination",
     "fastapi-utils",

--- a/src/cactus_orchestrator/api/admin.py
+++ b/src/cactus_orchestrator/api/admin.py
@@ -23,13 +23,13 @@ from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from cactus_orchestrator import artifact
-from cactus_orchestrator.api.procedure import test_procedures_by_id
-from cactus_orchestrator.api.run import (
-    get_run_artifact_response_for_user,
+from cactus_orchestrator.api.common import (
     map_run_to_run_response,
     select_user_or_raise,
     select_user_run_group_or_raise,
+    test_procedures_by_id,
 )
+from cactus_orchestrator.api.run import get_run_artifact_response_for_user
 from cactus_orchestrator.api.run_group import map_group_to_group_response
 from cactus_orchestrator.artifact import regenerate_run_artifact
 from cactus_orchestrator.chart import generate_power_limit_chart
@@ -220,6 +220,7 @@ async def admin_get_procedure_run_summaries_for_group(
                     latest_run_status=agg.latest_run_status,
                     latest_run_id=agg.latest_run_id,
                     latest_run_timestamp=agg.latest_run_timestamp,
+                    immediate_start=definition.preconditions is not None and definition.preconditions.immediate_start,
                 )
             )
 

--- a/src/cactus_orchestrator/api/common.py
+++ b/src/cactus_orchestrator/api/common.py
@@ -4,6 +4,8 @@ from http import HTTPStatus
 from cactus_schema.orchestrator import PlaylistRunInfo, RunResponse, RunStatusResponse
 from cactus_test_definitions.client import get_all_test_procedures
 from cactus_test_definitions.client.test_procedures import TestProcedure, TestProcedureId
+
+from cactus_orchestrator.settings import get_current_settings
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from cactus_orchestrator.auth import UserContext
@@ -13,7 +15,13 @@ from cactus_orchestrator.model import Run, RunGroup, RunStatus, User
 
 logger = logging.getLogger(__name__)
 
-test_procedures_by_id: dict[TestProcedureId, TestProcedure] = get_all_test_procedures()
+
+def get_filtered_test_procedures() -> dict[TestProcedureId, TestProcedure]:
+    ignored = set(get_current_settings().ignored_test_procedures)
+    return {k: v for k, v in get_all_test_procedures().items() if k.value not in ignored}
+
+
+test_procedures_by_id: dict[TestProcedureId, TestProcedure] = get_filtered_test_procedures()
 
 
 def map_run_status_to_run_status_response(run_status: RunStatus) -> RunStatusResponse:

--- a/src/cactus_orchestrator/api/common.py
+++ b/src/cactus_orchestrator/api/common.py
@@ -2,10 +2,9 @@ import logging
 from http import HTTPStatus
 
 from cactus_schema.orchestrator import PlaylistRunInfo, RunResponse, RunStatusResponse
-from cactus_test_definitions.client import get_all_test_procedures
 from cactus_test_definitions.client.test_procedures import TestProcedure, TestProcedureId
 
-from cactus_orchestrator.settings import get_current_settings
+from cactus_orchestrator.procedures import get_filtered_test_procedures
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from cactus_orchestrator.auth import UserContext
@@ -14,11 +13,6 @@ from cactus_orchestrator.k8s.resource import generate_envoy_dcap_uri, get_resour
 from cactus_orchestrator.model import Run, RunGroup, RunStatus, User
 
 logger = logging.getLogger(__name__)
-
-
-def get_filtered_test_procedures() -> dict[TestProcedureId, TestProcedure]:
-    ignored = set(get_current_settings().ignored_test_procedures)
-    return {k: v for k, v in get_all_test_procedures().items() if k.value not in ignored}
 
 
 test_procedures_by_id: dict[TestProcedureId, TestProcedure] = get_filtered_test_procedures()

--- a/src/cactus_orchestrator/api/common.py
+++ b/src/cactus_orchestrator/api/common.py
@@ -1,14 +1,56 @@
 import logging
 from http import HTTPStatus
 
+from cactus_schema.orchestrator import PlaylistRunInfo, RunResponse, RunStatusResponse
+from cactus_test_definitions.client import get_all_test_procedures
+from cactus_test_definitions.client.test_procedures import TestProcedure, TestProcedureId
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
-
 from cactus_orchestrator.auth import UserContext
 from cactus_orchestrator.crud import insert_user, select_run_group_for_user, select_run_groups_for_user, select_user
-from cactus_orchestrator.model import RunGroup, User
+from cactus_orchestrator.k8s.resource import generate_envoy_dcap_uri, get_resource_names
+from cactus_orchestrator.model import Run, RunGroup, RunStatus, User
 
 logger = logging.getLogger(__name__)
+
+test_procedures_by_id: dict[TestProcedureId, TestProcedure] = get_all_test_procedures()
+
+
+def map_run_status_to_run_status_response(run_status: RunStatus) -> RunStatusResponse:
+    status = RunStatusResponse.finalised
+    if run_status == RunStatus.initialised:
+        status = RunStatusResponse.initialised
+    elif run_status == RunStatus.started:
+        status = RunStatusResponse.started
+    elif run_status == RunStatus.provisioning:
+        status = RunStatusResponse.provisioning
+    elif run_status == RunStatus.skipped:
+        status = RunStatusResponse.skipped
+    return status
+
+
+def map_run_to_run_response(run: Run, playlist_runs: list[PlaylistRunInfo] | None = None) -> RunResponse:
+    status = map_run_status_to_run_status_response(run.run_status)
+    try:
+        definition = test_procedures_by_id.get(TestProcedureId(run.testprocedure_id), None)
+    except ValueError:
+        definition = None
+
+    return RunResponse(
+        run_id=run.run_id,
+        test_procedure_id=run.testprocedure_id,
+        test_url=generate_envoy_dcap_uri(get_resource_names(run.teststack_id)),
+        status=status,
+        all_criteria_met=run.all_criteria_met,
+        created_at=run.created_at,
+        finalised_at=run.finalised_at,
+        is_device_cert=run.is_device_cert,
+        has_artifacts=run.run_artifact_id is not None,
+        playlist_execution_id=run.playlist_execution_id,
+        playlist_order=run.playlist_order,
+        playlist_runs=playlist_runs,
+        classes=definition.classes if definition else None,
+    )
 
 
 async def select_user_or_create(session: AsyncSession, user_context: UserContext) -> User:

--- a/src/cactus_orchestrator/api/procedure.py
+++ b/src/cactus_orchestrator/api/procedure.py
@@ -13,7 +13,11 @@ from cactus_schema.orchestrator import (
 from cactus_test_definitions import CSIPAusVersion
 from cactus_test_definitions.client import TestProcedure, TestProcedureId
 
-from cactus_orchestrator.api.common import map_run_to_run_response, select_user_run_group_or_raise, test_procedures_by_id
+from cactus_orchestrator.api.common import (
+    map_run_to_run_response,
+    select_user_run_group_or_raise,
+    test_procedures_by_id,
+)
 from cactus_orchestrator.auth import AuthPerm, UserContext, jwt_validator
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi_async_sqlalchemy import db

--- a/src/cactus_orchestrator/api/procedure.py
+++ b/src/cactus_orchestrator/api/procedure.py
@@ -11,14 +11,14 @@ from cactus_schema.orchestrator import (
     uri,
 )
 from cactus_test_definitions import CSIPAusVersion
-from cactus_test_definitions.client import TestProcedure, TestProcedureId, get_all_test_procedures
+from cactus_test_definitions.client import TestProcedure, TestProcedureId
+
+from cactus_orchestrator.api.common import map_run_to_run_response, select_user_run_group_or_raise, test_procedures_by_id
+from cactus_orchestrator.auth import AuthPerm, UserContext, jwt_validator
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi_async_sqlalchemy import db
 from fastapi_pagination import Page, paginate
 from fastapi_pagination.utils import disable_installed_extensions_check
-
-from cactus_orchestrator.api.run import map_run_to_run_response, select_user_run_group_or_raise
-from cactus_orchestrator.auth import AuthPerm, UserContext, jwt_validator
 from cactus_orchestrator.crud import select_group_runs_aggregated_by_procedure, select_group_runs_for_procedure
 from cactus_orchestrator.settings import get_current_settings
 
@@ -55,8 +55,6 @@ def map_versions() -> list[CSIPAusVersionResponse]:
     ]
 
 
-# Test procedures
-test_procedures_by_id = get_all_test_procedures()
 test_procedure_responses = map_from_definitions_to_responses(test_procedures_by_id)
 
 
@@ -127,6 +125,7 @@ async def get_procedure_run_summaries_for_group(
                     latest_run_status=agg.latest_run_status,
                     latest_run_id=agg.latest_run_id,
                     latest_run_timestamp=agg.latest_run_timestamp,
+                    immediate_start=definition.preconditions is not None and definition.preconditions.immediate_start,
                 )
             )
 

--- a/src/cactus_orchestrator/api/run.py
+++ b/src/cactus_orchestrator/api/run.py
@@ -21,7 +21,6 @@ from cactus_schema.orchestrator import (
     ProceedResponse,
     RunArtifactMultipleRequest,
     RunResponse,
-    RunStatusResponse,
     StartRunResponse,
     uri,
 )
@@ -82,8 +81,6 @@ logger = logging.getLogger(__name__)
 
 
 router = APIRouter()
-
-
 
 
 async def prepare_run_for_delete(run: Run) -> None:

--- a/src/cactus_orchestrator/api/run.py
+++ b/src/cactus_orchestrator/api/run.py
@@ -30,6 +30,7 @@ from cactus_schema.runner import RunGroup as RunRequestRunGroup
 from cactus_schema.runner import RunnerStatus, RunRequest, TestCertificates, TestConfig, TestDefinition, TestUser
 from cactus_test_definitions import CSIPAusVersion
 from cactus_test_definitions.client.test_procedures import TestProcedureId, get_yaml_contents
+
 from cryptography import x509
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi_async_sqlalchemy import db
@@ -37,7 +38,12 @@ from fastapi_pagination import Page, paginate
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cactus_orchestrator.api.common import select_user_or_raise, select_user_run_group_or_raise
+from cactus_orchestrator.api.common import (
+    map_run_status_to_run_status_response,
+    map_run_to_run_response,
+    select_user_or_raise,
+    select_user_run_group_or_raise,
+)
 from cactus_orchestrator.artifact import regenerate_pdf_report
 from cactus_orchestrator.chart import generate_power_limit_chart
 from cactus_orchestrator.auth import AuthPerm, UserContext, jwt_validator
@@ -78,36 +84,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def map_run_status_to_run_status_response(run_status: RunStatus) -> RunStatusResponse:
-    status = RunStatusResponse.finalised
-    if run_status == RunStatus.initialised:
-        status = RunStatusResponse.initialised
-    elif run_status == RunStatus.started:
-        status = RunStatusResponse.started
-    elif run_status == RunStatus.provisioning:
-        status = RunStatusResponse.provisioning
-    elif run_status == RunStatus.skipped:
-        status = RunStatusResponse.skipped
-    return status
-
-
-def map_run_to_run_response(run: Run, playlist_runs: list[PlaylistRunInfo] | None = None) -> RunResponse:
-    status = map_run_status_to_run_status_response(run.run_status)
-
-    return RunResponse(
-        run_id=run.run_id,
-        test_procedure_id=run.testprocedure_id,
-        test_url=generate_envoy_dcap_uri(get_resource_names(run.teststack_id)),
-        status=status,
-        all_criteria_met=run.all_criteria_met,
-        created_at=run.created_at,
-        finalised_at=run.finalised_at,
-        is_device_cert=run.is_device_cert,
-        has_artifacts=run.run_artifact_id is not None,
-        playlist_execution_id=run.playlist_execution_id,
-        playlist_order=run.playlist_order,
-        playlist_runs=playlist_runs,
-    )
 
 
 async def prepare_run_for_delete(run: Run) -> None:

--- a/src/cactus_orchestrator/procedures.py
+++ b/src/cactus_orchestrator/procedures.py
@@ -1,0 +1,9 @@
+from cactus_test_definitions.client import get_all_test_procedures
+from cactus_test_definitions.client.test_procedures import TestProcedure, TestProcedureId
+
+from cactus_orchestrator.settings import get_current_settings
+
+
+def get_filtered_test_procedures() -> dict[TestProcedureId, TestProcedure]:
+    ignored = set(get_current_settings().ignored_test_procedures)
+    return {k: v for k, v in get_all_test_procedures().items() if k.value not in ignored}

--- a/src/cactus_orchestrator/reporting/compliance.py
+++ b/src/cactus_orchestrator/reporting/compliance.py
@@ -4,9 +4,10 @@ from enum import Enum, auto
 
 from cactus_schema.orchestrator import TestProcedureRunSummaryResponse
 from cactus_schema.orchestrator.compliance import ComplianceClass, fetch_compliance_classes
-from cactus_test_definitions.client import TestProcedureId, get_all_test_procedures
+from cactus_test_definitions.client import TestProcedureId
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from cactus_orchestrator.api.common import get_filtered_test_procedures
 from cactus_orchestrator.crud import select_group_runs_aggregated_by_procedure
 from cactus_orchestrator.model import RunGroup
 
@@ -77,7 +78,7 @@ async def get_class_compliance(
 async def get_procedure_mapping(
     session: AsyncSession, run_group: RunGroup
 ) -> dict[TestProcedureId, TestProcedureRunSummaryResponse]:
-    test_procedure_definitions = get_all_test_procedures()
+    test_procedure_definitions = get_filtered_test_procedures()
 
     procedures: list[TestProcedureRunSummaryResponse] = []
     for agg in await select_group_runs_aggregated_by_procedure(session=session, run_group_id=run_group.run_group_id):

--- a/src/cactus_orchestrator/reporting/compliance.py
+++ b/src/cactus_orchestrator/reporting/compliance.py
@@ -7,7 +7,7 @@ from cactus_schema.orchestrator.compliance import ComplianceClass, fetch_complia
 from cactus_test_definitions.client import TestProcedureId
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from cactus_orchestrator.api.common import get_filtered_test_procedures
+from cactus_orchestrator.procedures import get_filtered_test_procedures
 from cactus_orchestrator.crud import select_group_runs_aggregated_by_procedure
 from cactus_orchestrator.model import RunGroup
 

--- a/src/cactus_orchestrator/settings.py
+++ b/src/cactus_orchestrator/settings.py
@@ -76,6 +76,7 @@ class CactusOrchestratorSettings(BaseSettings):
 
     # general orchestrator options
     ignored_csip_aus_versions: list[str] = []
+    ignored_test_procedures: list[str] = []
 
 
 class JWTAuthSettings(BaseSettings):


### PR DESCRIPTION
Best to deploy this at same time as the changes to the UI (same PR name).

A few changes:
1) Use the new cactus-schema to send immediate_start, classes.
2) Filter test procedure ids by an optional env var just like filtering out versions.
3) Move a couple functions to common.py: map_run_status_to_run_status_response, map_run_to_run_response due to some circular import issues.