### PR TITLE
Fixed active power charts for legacy envoy db schema

### DIFF
--- a/src/cactus_orchestrator/power_limit_chart.py
+++ b/src/cactus_orchestrator/power_limit_chart.py
@@ -56,9 +56,6 @@ _STEP_PALETTE = [
     "rgba(120,220,220,0.45)",
 ]
 
-# Subquery that resolves the active site — most recently modified site row.
-_ACTIVE_SITE_ID_SQL = "(SELECT site_id FROM site ORDER BY changed_time DESC LIMIT 1)"
-
 
 # ─── Raw DB row types ─────────────────────────────────────────────────────────
 
@@ -77,7 +74,9 @@ class _RawControlGroup:
 
 @dataclass
 class _RawDOE:
-    """Minimal DOE columns fetched from either the active or archive DOE table."""
+    """Minimal DOE columns fetched from either the active or archive DOE table.
+
+    Changing this has backwards compatibility considerations with old versions of the envoy DB schema"""
 
     dynamic_operating_envelope_id: int
     site_control_group_id: int
@@ -99,7 +98,9 @@ class _RawDOE:
 
 @dataclass
 class _RawDefault:
-    """Minimal default-control columns from the active or archive default table."""
+    """Minimal site-control-default columns from the active or archive default table.
+
+    Changing this has backwards compatibility considerations with old versions of the envoy DB schema"""
 
     site_control_group_id: int
     changed_time: datetime
@@ -185,11 +186,13 @@ class _ReceiptMarker:
 async def _get_der_setting(session: AsyncSession) -> _RawDERSetting | None:
     result = await session.execute(
         text(
-            f"SELECT sds.max_w_value, sds.max_w_multiplier"
-            f" FROM site_der_setting sds"
-            f" JOIN site_der sd ON sd.site_der_id = sds.site_der_id"
-            f" WHERE sd.site_id = {_ACTIVE_SITE_ID_SQL}"
-            f" LIMIT 1"
+            """
+SELECT sds.max_w_value, sds.max_w_multiplier
+FROM site_der_setting sds
+JOIN site_der sd ON sd.site_der_id = sds.site_der_id
+WHERE sd.site_id = (SELECT site_id FROM site ORDER BY changed_time DESC LIMIT 1)
+LIMIT 1
+            """
         )
     )
     row = result.first()
@@ -199,13 +202,8 @@ async def _get_der_setting(session: AsyncSession) -> _RawDERSetting | None:
 
 
 async def _get_control_groups(session: AsyncSession) -> list[_RawControlGroup]:
-    result = await session.execute(
-        text("SELECT site_control_group_id, primacy FROM site_control_group")
-    )
-    return [
-        _RawControlGroup(site_control_group_id=row.site_control_group_id, primacy=row.primacy)
-        for row in result
-    ]
+    result = await session.execute(text("SELECT site_control_group_id, primacy FROM site_control_group"))
+    return [_RawControlGroup(site_control_group_id=row.site_control_group_id, primacy=row.primacy) for row in result]
 
 
 async def _get_subscribed_group_ids(session: AsyncSession) -> set[int]:
@@ -213,10 +211,7 @@ async def _get_subscribed_group_ids(session: AsyncSession) -> set[int]:
     Only subscriptions with an explicit resource_id are considered; 0 subscriptions is valid
     (device relies entirely on polling)."""
     result = await session.execute(
-        text(
-            "SELECT resource_id FROM subscription"
-            " WHERE resource_type = :rtype AND resource_id IS NOT NULL"
-        ),
+        text("SELECT resource_id FROM subscription WHERE resource_type = :rtype AND resource_id IS NOT NULL"),
         {"rtype": SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE.value},
     )
     return {row.resource_id for row in result}
@@ -226,45 +221,47 @@ async def _get_does(session: AsyncSession) -> list[_RawDOE]:
     """Fetch all active and archived DOEs for the active site using explicit column selection."""
     result = await session.execute(
         text(
-            f"SELECT"
-            f"  dynamic_operating_envelope_id,"
-            f"  site_control_group_id,"
-            f"  created_time,"
-            f"  start_time,"
-            f"  duration_seconds,"
-            f"  superseded,"
-            f"  export_limit_watts,"
-            f"  generation_limit_active_watts,"
-            f"  import_limit_active_watts,"
-            f"  load_limit_active_watts,"
-            f"  set_connected,"
-            f"  set_energized,"
-            f"  ramp_time_seconds,"
-            f"  false AS is_archive,"
-            f"  NULL AS deleted_time,"
-            f"  NULL AS archive_time"
-            f" FROM dynamic_operating_envelope"
-            f" WHERE site_id = {_ACTIVE_SITE_ID_SQL}"
-            f" UNION ALL"
-            f" SELECT"
-            f"  dynamic_operating_envelope_id,"
-            f"  site_control_group_id,"
-            f"  created_time,"
-            f"  start_time,"
-            f"  duration_seconds,"
-            f"  superseded,"
-            f"  export_limit_watts,"
-            f"  generation_limit_active_watts,"
-            f"  import_limit_active_watts,"
-            f"  load_limit_active_watts,"
-            f"  set_connected,"
-            f"  set_energized,"
-            f"  ramp_time_seconds,"
-            f"  true AS is_archive,"
-            f"  deleted_time,"
-            f"  archive_time"
-            f" FROM archive_dynamic_operating_envelope"
-            f" WHERE site_id = {_ACTIVE_SITE_ID_SQL}"
+            """
+SELECT
+    dynamic_operating_envelope_id,
+    site_control_group_id,
+    created_time,
+    start_time,
+    duration_seconds,
+    superseded,
+    export_limit_watts,
+    generation_limit_active_watts,
+    import_limit_active_watts,
+    load_limit_active_watts,
+    set_connected,
+    set_energized,
+    ramp_time_seconds,
+    false AS is_archive,
+    NULL AS deleted_time,
+    NULL AS archive_time
+    FROM dynamic_operating_envelope
+    WHERE site_id = (SELECT site_id FROM site ORDER BY changed_time DESC LIMIT 1)
+UNION ALL
+SELECT
+    dynamic_operating_envelope_id,
+    site_control_group_id,
+    created_time,
+    start_time,
+    duration_seconds,
+    superseded,
+    export_limit_watts,
+    generation_limit_active_watts,
+    import_limit_active_watts,
+    load_limit_active_watts,
+    set_connected,
+    set_energized,
+    ramp_time_seconds,
+    true AS is_archive,
+    deleted_time,
+    archive_time
+    FROM archive_dynamic_operating_envelope
+    WHERE site_id = (SELECT site_id FROM site ORDER BY changed_time DESC LIMIT 1)
+            """
         )
     )
     does: list[_RawDOE] = []
@@ -278,9 +275,15 @@ async def _get_does(session: AsyncSession) -> list[_RawDOE]:
                 duration_seconds=row.duration_seconds,
                 superseded=bool(row.superseded),
                 export_limit_watts=float(row.export_limit_watts) if row.export_limit_watts is not None else None,
-                generation_limit_active_watts=float(row.generation_limit_active_watts) if row.generation_limit_active_watts is not None else None,
-                import_limit_active_watts=float(row.import_limit_active_watts) if row.import_limit_active_watts is not None else None,
-                load_limit_active_watts=float(row.load_limit_active_watts) if row.load_limit_active_watts is not None else None,
+                generation_limit_active_watts=float(row.generation_limit_active_watts)
+                if row.generation_limit_active_watts is not None
+                else None,
+                import_limit_active_watts=float(row.import_limit_active_watts)
+                if row.import_limit_active_watts is not None
+                else None,
+                load_limit_active_watts=float(row.load_limit_active_watts)
+                if row.load_limit_active_watts is not None
+                else None,
                 set_connected=row.set_connected,
                 set_energized=row.set_energized,
                 ramp_time_seconds=float(row.ramp_time_seconds) if row.ramp_time_seconds is not None else None,
@@ -295,31 +298,31 @@ async def _get_does(session: AsyncSession) -> list[_RawDOE]:
 async def _get_defaults(session: AsyncSession) -> list[_RawDefault]:
     """Fetch all active and archived SiteControlGroupDefaults using explicit column selection."""
     result = await session.execute(
-        text(
-            "SELECT"
-            "  site_control_group_id,"
-            "  changed_time,"
-            "  export_limit_active_watts,"
-            "  generation_limit_active_watts,"
-            "  import_limit_active_watts,"
-            "  load_limit_active_watts,"
-            "  ramp_rate_percent_per_second,"
-            "  false AS is_archive,"
-            "  NULL AS archive_time"
-            " FROM site_control_group_default"
-            " UNION ALL"
-            " SELECT"
-            "  site_control_group_id,"
-            "  changed_time,"
-            "  export_limit_active_watts,"
-            "  generation_limit_active_watts,"
-            "  import_limit_active_watts,"
-            "  load_limit_active_watts,"
-            "  ramp_rate_percent_per_second,"
-            "  true AS is_archive,"
-            "  archive_time"
-            " FROM archive_site_control_group_default"
-        )
+        text("""
+SELECT
+    site_control_group_id,
+    changed_time,
+    export_limit_active_watts,
+    generation_limit_active_watts,
+    import_limit_active_watts,
+    load_limit_active_watts,
+    ramp_rate_percent_per_second,
+    false AS is_archive,
+    NULL AS archive_time
+    FROM site_control_group_default
+UNION ALL
+SELECT
+    site_control_group_id,
+    changed_time,
+    export_limit_active_watts,
+    generation_limit_active_watts,
+    import_limit_active_watts,
+    load_limit_active_watts,
+    ramp_rate_percent_per_second,
+    true AS is_archive,
+    archive_time
+    FROM archive_site_control_group_default
+        """)
     )
     defaults: list[_RawDefault] = []
     for row in result:
@@ -327,10 +330,18 @@ async def _get_defaults(session: AsyncSession) -> list[_RawDefault]:
             _RawDefault(
                 site_control_group_id=row.site_control_group_id,
                 changed_time=row.changed_time,
-                export_limit_active_watts=float(row.export_limit_active_watts) if row.export_limit_active_watts is not None else None,
-                generation_limit_active_watts=float(row.generation_limit_active_watts) if row.generation_limit_active_watts is not None else None,
-                import_limit_active_watts=float(row.import_limit_active_watts) if row.import_limit_active_watts is not None else None,
-                load_limit_active_watts=float(row.load_limit_active_watts) if row.load_limit_active_watts is not None else None,
+                export_limit_active_watts=float(row.export_limit_active_watts)
+                if row.export_limit_active_watts is not None
+                else None,
+                generation_limit_active_watts=float(row.generation_limit_active_watts)
+                if row.generation_limit_active_watts is not None
+                else None,
+                import_limit_active_watts=float(row.import_limit_active_watts)
+                if row.import_limit_active_watts is not None
+                else None,
+                load_limit_active_watts=float(row.load_limit_active_watts)
+                if row.load_limit_active_watts is not None
+                else None,
                 ramp_rate_percent_per_second=row.ramp_rate_percent_per_second,
                 is_archive=bool(row.is_archive),
                 archive_time=row.archive_time,

--- a/src/cactus_orchestrator/power_limit_chart.py
+++ b/src/cactus_orchestrator/power_limit_chart.py
@@ -24,24 +24,9 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 
 import plotly.graph_objects as go  # type: ignore[import-untyped]
-from cactus_runner.app.envoy_common import (
-    get_active_site,
-    get_site_control_group_defaults_with_archive,
-    get_site_controls_active_archived,
-)
 from cactus_schema.runner.schema import RequestEntry
-from envoy.server.model.archive.doe import (
-    ArchiveDynamicOperatingEnvelope,
-    ArchiveSiteControlGroupDefault,
-)
-from envoy.server.model.doe import (
-    DynamicOperatingEnvelope,
-    SiteControlGroup,
-    SiteControlGroupDefault,
-)
-from envoy.server.model.site import SiteDERSetting
-from envoy.server.model.subscription import Subscription, SubscriptionResource
-from sqlalchemy import select
+from envoy.server.model.subscription import SubscriptionResource
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -61,9 +46,6 @@ _POST_DISCONNECT_WGRA_SECONDS: float = 6 * 60.0
 # Matches /edev/{n}/derp/{group_id}/derc (with optional query string)
 _DERC_PATH_RE = re.compile(r"/edev/\d+/derp/(\d+)/derc")
 
-# Type alias for default control models (active or archived)
-_DefaultLike = SiteControlGroupDefault | ArchiveSiteControlGroupDefault
-
 # Cycling colour palette for step-name bands (semi-transparent fills)
 _STEP_PALETTE = [
     "rgba(130,179,255,0.45)",
@@ -74,15 +56,73 @@ _STEP_PALETTE = [
     "rgba(120,220,220,0.45)",
 ]
 
+# Subquery that resolves the active site — most recently modified site row.
+_ACTIVE_SITE_ID_SQL = "(SELECT site_id FROM site ORDER BY changed_time DESC LIMIT 1)"
+
+
+# ─── Raw DB row types ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class _RawDERSetting:
+    max_w_value: int
+    max_w_multiplier: int
+
+
+@dataclass
+class _RawControlGroup:
+    site_control_group_id: int
+    primacy: int
+
+
+@dataclass
+class _RawDOE:
+    """Minimal DOE columns fetched from either the active or archive DOE table."""
+
+    dynamic_operating_envelope_id: int
+    site_control_group_id: int
+    created_time: datetime
+    start_time: datetime
+    duration_seconds: int
+    superseded: bool
+    export_limit_watts: float | None
+    generation_limit_active_watts: float | None
+    import_limit_active_watts: float | None
+    load_limit_active_watts: float | None
+    set_connected: bool | None
+    set_energized: bool | None
+    ramp_time_seconds: float | None
+    is_archive: bool
+    deleted_time: datetime | None  # archive rows only
+    archive_time: datetime | None  # archive rows only
+
+
+@dataclass
+class _RawDefault:
+    """Minimal default-control columns from the active or archive default table."""
+
+    site_control_group_id: int
+    changed_time: datetime
+    export_limit_active_watts: float | None
+    generation_limit_active_watts: float | None
+    import_limit_active_watts: float | None
+    load_limit_active_watts: float | None
+    ramp_rate_percent_per_second: int | None
+    is_archive: bool
+    archive_time: datetime | None  # archive rows only
+
 
 # ─── Internal data types ──────────────────────────────────────────────────────
+
+# Type alias kept for readability in function signatures.
+_DefaultLike = _RawDefault
 
 
 @dataclass
 class _EnrichedControl:
     """DERControl with receipt time and effective window pre-computed."""
 
-    doe: DynamicOperatingEnvelope | ArchiveDynamicOperatingEnvelope
+    doe: _RawDOE
     site_control_group_id: int
     primacy: int
     receipt_time: datetime
@@ -92,23 +132,19 @@ class _EnrichedControl:
 
     @property
     def export_limit(self) -> float | None:
-        v = self.doe.export_limit_watts
-        return float(v) if v is not None else None
+        return self.doe.export_limit_watts
 
     @property
     def gen_limit(self) -> float | None:
-        v = self.doe.generation_limit_active_watts
-        return float(v) if v is not None else None
+        return self.doe.generation_limit_active_watts
 
     @property
     def import_limit(self) -> float | None:
-        v = self.doe.import_limit_active_watts
-        return float(v) if v is not None else None
+        return self.doe.import_limit_active_watts
 
     @property
     def load_limit(self) -> float | None:
-        v = self.doe.load_limit_active_watts
-        return float(v) if v is not None else None
+        return self.doe.load_limit_active_watts
 
     @property
     def set_connected(self) -> bool | None:
@@ -120,8 +156,7 @@ class _EnrichedControl:
 
     @property
     def ramp_time_seconds(self) -> float | None:
-        v = self.doe.ramp_time_seconds
-        return float(v) if v is not None else None
+        return self.doe.ramp_time_seconds
 
 
 @dataclass
@@ -147,19 +182,30 @@ class _ReceiptMarker:
 # ─── DB queries ───────────────────────────────────────────────────────────────
 
 
-async def _get_der_setting(session: AsyncSession) -> SiteDERSetting | None:
-    site = await get_active_site(session, include_der_settings=True)
-    if site is None:
+async def _get_der_setting(session: AsyncSession) -> _RawDERSetting | None:
+    result = await session.execute(
+        text(
+            f"SELECT sds.max_w_value, sds.max_w_multiplier"
+            f" FROM site_der_setting sds"
+            f" JOIN site_der sd ON sd.site_der_id = sds.site_der_id"
+            f" WHERE sd.site_id = {_ACTIVE_SITE_ID_SQL}"
+            f" LIMIT 1"
+        )
+    )
+    row = result.first()
+    if row is None:
         return None
-    for der in site.site_ders:
-        if der.site_der_setting is not None:
-            return der.site_der_setting
-    return None
+    return _RawDERSetting(max_w_value=row.max_w_value, max_w_multiplier=row.max_w_multiplier)
 
 
-async def _get_control_groups(session: AsyncSession) -> list[SiteControlGroup]:
-    result = await session.execute(select(SiteControlGroup))
-    return list(result.scalars().all())
+async def _get_control_groups(session: AsyncSession) -> list[_RawControlGroup]:
+    result = await session.execute(
+        text("SELECT site_control_group_id, primacy FROM site_control_group")
+    )
+    return [
+        _RawControlGroup(site_control_group_id=row.site_control_group_id, primacy=row.primacy)
+        for row in result
+    ]
 
 
 async def _get_subscribed_group_ids(session: AsyncSession) -> set[int]:
@@ -167,12 +213,130 @@ async def _get_subscribed_group_ids(session: AsyncSession) -> set[int]:
     Only subscriptions with an explicit resource_id are considered; 0 subscriptions is valid
     (device relies entirely on polling)."""
     result = await session.execute(
-        select(Subscription).where(
-            Subscription.resource_type == SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE,
-            Subscription.resource_id.is_not(None),
+        text(
+            "SELECT resource_id FROM subscription"
+            " WHERE resource_type = :rtype AND resource_id IS NOT NULL"
+        ),
+        {"rtype": SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE.value},
+    )
+    return {row.resource_id for row in result}
+
+
+async def _get_does(session: AsyncSession) -> list[_RawDOE]:
+    """Fetch all active and archived DOEs for the active site using explicit column selection."""
+    result = await session.execute(
+        text(
+            f"SELECT"
+            f"  dynamic_operating_envelope_id,"
+            f"  site_control_group_id,"
+            f"  created_time,"
+            f"  start_time,"
+            f"  duration_seconds,"
+            f"  superseded,"
+            f"  export_limit_watts,"
+            f"  generation_limit_active_watts,"
+            f"  import_limit_active_watts,"
+            f"  load_limit_active_watts,"
+            f"  set_connected,"
+            f"  set_energized,"
+            f"  ramp_time_seconds,"
+            f"  false AS is_archive,"
+            f"  NULL AS deleted_time,"
+            f"  NULL AS archive_time"
+            f" FROM dynamic_operating_envelope"
+            f" WHERE site_id = {_ACTIVE_SITE_ID_SQL}"
+            f" UNION ALL"
+            f" SELECT"
+            f"  dynamic_operating_envelope_id,"
+            f"  site_control_group_id,"
+            f"  created_time,"
+            f"  start_time,"
+            f"  duration_seconds,"
+            f"  superseded,"
+            f"  export_limit_watts,"
+            f"  generation_limit_active_watts,"
+            f"  import_limit_active_watts,"
+            f"  load_limit_active_watts,"
+            f"  set_connected,"
+            f"  set_energized,"
+            f"  ramp_time_seconds,"
+            f"  true AS is_archive,"
+            f"  deleted_time,"
+            f"  archive_time"
+            f" FROM archive_dynamic_operating_envelope"
+            f" WHERE site_id = {_ACTIVE_SITE_ID_SQL}"
         )
     )
-    return {sub.resource_id for sub in result.scalars().all() if sub.resource_id is not None}
+    does: list[_RawDOE] = []
+    for row in result:
+        does.append(
+            _RawDOE(
+                dynamic_operating_envelope_id=row.dynamic_operating_envelope_id,
+                site_control_group_id=row.site_control_group_id,
+                created_time=row.created_time,
+                start_time=row.start_time,
+                duration_seconds=row.duration_seconds,
+                superseded=bool(row.superseded),
+                export_limit_watts=float(row.export_limit_watts) if row.export_limit_watts is not None else None,
+                generation_limit_active_watts=float(row.generation_limit_active_watts) if row.generation_limit_active_watts is not None else None,
+                import_limit_active_watts=float(row.import_limit_active_watts) if row.import_limit_active_watts is not None else None,
+                load_limit_active_watts=float(row.load_limit_active_watts) if row.load_limit_active_watts is not None else None,
+                set_connected=row.set_connected,
+                set_energized=row.set_energized,
+                ramp_time_seconds=float(row.ramp_time_seconds) if row.ramp_time_seconds is not None else None,
+                is_archive=bool(row.is_archive),
+                deleted_time=row.deleted_time,
+                archive_time=row.archive_time,
+            )
+        )
+    return does
+
+
+async def _get_defaults(session: AsyncSession) -> list[_RawDefault]:
+    """Fetch all active and archived SiteControlGroupDefaults using explicit column selection."""
+    result = await session.execute(
+        text(
+            "SELECT"
+            "  site_control_group_id,"
+            "  changed_time,"
+            "  export_limit_active_watts,"
+            "  generation_limit_active_watts,"
+            "  import_limit_active_watts,"
+            "  load_limit_active_watts,"
+            "  ramp_rate_percent_per_second,"
+            "  false AS is_archive,"
+            "  NULL AS archive_time"
+            " FROM site_control_group_default"
+            " UNION ALL"
+            " SELECT"
+            "  site_control_group_id,"
+            "  changed_time,"
+            "  export_limit_active_watts,"
+            "  generation_limit_active_watts,"
+            "  import_limit_active_watts,"
+            "  load_limit_active_watts,"
+            "  ramp_rate_percent_per_second,"
+            "  true AS is_archive,"
+            "  archive_time"
+            " FROM archive_site_control_group_default"
+        )
+    )
+    defaults: list[_RawDefault] = []
+    for row in result:
+        defaults.append(
+            _RawDefault(
+                site_control_group_id=row.site_control_group_id,
+                changed_time=row.changed_time,
+                export_limit_active_watts=float(row.export_limit_active_watts) if row.export_limit_active_watts is not None else None,
+                generation_limit_active_watts=float(row.generation_limit_active_watts) if row.generation_limit_active_watts is not None else None,
+                import_limit_active_watts=float(row.import_limit_active_watts) if row.import_limit_active_watts is not None else None,
+                load_limit_active_watts=float(row.load_limit_active_watts) if row.load_limit_active_watts is not None else None,
+                ramp_rate_percent_per_second=row.ramp_rate_percent_per_second,
+                is_archive=bool(row.is_archive),
+                archive_time=row.archive_time,
+            )
+        )
+    return defaults
 
 
 # ─── Control-interval and receipt-marker helpers ──────────────────────────────
@@ -180,7 +344,7 @@ async def _get_subscribed_group_ids(session: AsyncSession) -> set[int]:
 
 def _compute_active_control_intervals(  # noqa: C901
     event_times: list[datetime],
-    sorted_groups: list[SiteControlGroup],
+    sorted_groups: list[_RawControlGroup],
     enriched: list[_EnrichedControl],
     defaults_by_group: dict[int, list[_DefaultLike]],
     test_end: datetime,
@@ -261,7 +425,7 @@ def _build_receipt_markers(
 
 
 def _compute_receipt_time_and_step(
-    doe: DynamicOperatingEnvelope | ArchiveDynamicOperatingEnvelope,
+    doe: _RawDOE,
     group_id: int,
     subscribed_group_ids: set[int],
     sorted_requests: list[RequestEntry],
@@ -305,12 +469,10 @@ def _compute_receipt_time_and_step(
 # ─── Control enrichment ───────────────────────────────────────────────────────
 
 
-def _effective_end_for_doe(
-    doe: DynamicOperatingEnvelope | ArchiveDynamicOperatingEnvelope,
-) -> datetime | None:
+def _effective_end_for_doe(doe: _RawDOE) -> datetime | None:
     """Returns the effective end time for a DOE, or None if no valid window exists."""
     base_end = doe.start_time + timedelta(seconds=doe.duration_seconds)
-    if isinstance(doe, ArchiveDynamicOperatingEnvelope):
+    if doe.is_archive:
         if doe.deleted_time is not None and doe.deleted_time > doe.start_time:
             return min(base_end, doe.deleted_time)
         if doe.archive_time is not None and doe.archive_time > doe.start_time:
@@ -320,9 +482,9 @@ def _effective_end_for_doe(
 
 
 def _build_enriched_controls(
-    all_does: list[DynamicOperatingEnvelope | ArchiveDynamicOperatingEnvelope],
+    all_does: list[_RawDOE],
     test_start: datetime,
-    groups_by_id: dict[int, SiteControlGroup],
+    groups_by_id: dict[int, _RawControlGroup],
     subscribed_group_ids: set[int],
     request_history: list[RequestEntry],
     doe_tags: dict[int, str],
@@ -380,7 +542,7 @@ def _build_enriched_controls(
 def _default_active_window(d: _DefaultLike) -> tuple[datetime, datetime] | None:
     """Returns the (start, end) time window during which this default was active.
     Returns None if the archive_time is missing (should not happen; silently ignored)."""
-    if isinstance(d, ArchiveSiteControlGroupDefault):
+    if d.is_archive:
         if d.archive_time is None:
             return None
         return d.changed_time, d.archive_time
@@ -461,9 +623,7 @@ def _find_active_control_at(
         if best is None:
             best = ctrl
         # Archive records take priority over active (they represent confirmed historical windows)
-        elif isinstance(ctrl.doe, ArchiveDynamicOperatingEnvelope) and not isinstance(
-            best.doe, ArchiveDynamicOperatingEnvelope
-        ):
+        elif ctrl.doe.is_archive and not best.doe.is_archive:
             best = ctrl
     return best
 
@@ -486,7 +646,7 @@ def _find_active_default_at(
 
 def _resolve_type_limit(
     t: datetime,
-    sorted_groups: list[SiteControlGroup],
+    sorted_groups: list[_RawControlGroup],
     enriched: list[_EnrichedControl],
     defaults_by_group: dict[int, list[_DefaultLike]],
     get_ctrl_val: Callable[[_EnrichedControl], float | None],
@@ -521,7 +681,7 @@ def _resolve_type_limit(
 
 def _get_effective_upper_at(
     t: datetime,
-    sorted_groups: list[SiteControlGroup],
+    sorted_groups: list[_RawControlGroup],
     enriched: list[_EnrichedControl],
     defaults_by_group: dict[int, list[_DefaultLike]],
 ) -> tuple[float | None, object | None]:
@@ -536,7 +696,7 @@ def _get_effective_upper_at(
         enriched,
         defaults_by_group,
         lambda c: c.export_limit,
-        lambda d: float(d.export_limit_active_watts) if d.export_limit_active_watts is not None else None,
+        lambda d: d.export_limit_active_watts,
     )
     gen_val, gen_src = _resolve_type_limit(
         t,
@@ -544,7 +704,7 @@ def _get_effective_upper_at(
         enriched,
         defaults_by_group,
         lambda c: c.gen_limit,
-        lambda d: float(d.generation_limit_active_watts) if d.generation_limit_active_watts is not None else None,
+        lambda d: d.generation_limit_active_watts,
     )
     if exp_val is not None and gen_val is not None:
         return (exp_val, exp_src) if exp_val <= gen_val else (gen_val, gen_src)
@@ -557,7 +717,7 @@ def _get_effective_upper_at(
 
 def _get_effective_lower_at(
     t: datetime,
-    sorted_groups: list[SiteControlGroup],
+    sorted_groups: list[_RawControlGroup],
     enriched: list[_EnrichedControl],
     defaults_by_group: dict[int, list[_DefaultLike]],
 ) -> tuple[float | None, object | None]:
@@ -573,7 +733,7 @@ def _get_effective_lower_at(
         enriched,
         defaults_by_group,
         lambda c: c.import_limit,
-        lambda d: float(d.import_limit_active_watts) if d.import_limit_active_watts is not None else None,
+        lambda d: d.import_limit_active_watts,
     )
     load_val, load_src = _resolve_type_limit(
         t,
@@ -581,7 +741,7 @@ def _get_effective_lower_at(
         enriched,
         defaults_by_group,
         lambda c: c.load_limit,
-        lambda d: float(d.load_limit_active_watts) if d.load_limit_active_watts is not None else None,
+        lambda d: d.load_limit_active_watts,
     )
     if imp_val is not None and load_val is not None:
         return (imp_val, imp_src) if imp_val <= load_val else (load_val, load_src)
@@ -677,7 +837,7 @@ def _collect_event_times(
 def _build_limit_events(
     is_upper: bool,
     event_times: list[datetime],
-    sorted_groups: list[SiteControlGroup],
+    sorted_groups: list[_RawControlGroup],
     enriched: list[_EnrichedControl],
     defaults_by_group: dict[int, list[_DefaultLike]],
     disconnect_intervals: list[tuple[datetime, datetime]],
@@ -1285,8 +1445,8 @@ async def generate_power_limit_chart_html(
     groups_by_id = {g.site_control_group_id: g for g in control_groups}
     sorted_groups = sorted(control_groups, key=lambda g: g.primacy)
 
-    all_does = await get_site_controls_active_archived(session)
-    all_defaults = await get_site_control_group_defaults_with_archive(session)
+    all_does = await _get_does(session)
+    all_defaults = await _get_defaults(session)
     defaults_by_group = _build_defaults_by_group(all_defaults)
 
     subscribed_group_ids = await _get_subscribed_group_ids(session)

--- a/tests/integration/test_power_limit_chart.py
+++ b/tests/integration/test_power_limit_chart.py
@@ -11,17 +11,29 @@ Run with:
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from http import HTTPStatus
+from itertools import product
 from pathlib import Path
 
 import pytest
-from assertical.fake.generator import generate_class_instance
+from assertical.asserts.generator import assert_class_instance_equality
+from assertical.fake.generator import clone_class_instance, generate_class_instance
 from assertical.fixtures.postgres import generate_async_session
 from cactus_schema.runner.schema import HTTPMethod, RequestEntry
+from envoy.server.model.archive.doe import ArchiveDynamicOperatingEnvelope, ArchiveSiteControlGroupDefault
 from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroup, SiteControlGroupDefault
 from envoy.server.model.site import Site, SiteDER, SiteDERSetting
 from envoy.server.model.subscription import Subscription, SubscriptionResource
 
-from cactus_orchestrator.power_limit_chart import generate_power_limit_chart_html
+from cactus_orchestrator.power_limit_chart import (
+    _get_control_groups,
+    _get_defaults,
+    _get_der_setting,
+    _get_does,
+    _get_subscribed_group_ids,
+    _RawDefault,
+    _RawDOE,
+    generate_power_limit_chart_html,
+)
 
 OUTPUT_DIR = Path("/tmp/cactus_charts")
 
@@ -89,7 +101,7 @@ def _make_doe(
     )
 
 
-def _make_der_site(aggregator_id: int, max_w: int = 10000, grad_w: int = 28) -> Site:
+def _make_site_with_setting(aggregator_id: int, max_w: int = 10000, grad_w: int = 28, seed: int = 1) -> Site:
     """Build a Site with one SiteDER and SiteDERSetting."""
     der_setting = generate_class_instance(
         SiteDERSetting,
@@ -100,16 +112,505 @@ def _make_der_site(aggregator_id: int, max_w: int = 10000, grad_w: int = 28) -> 
         grad_w=grad_w,
         soft_grad_w=None,
     )
-    der = generate_class_instance(SiteDER, seed=1, site_id=None, site_der_setting=der_setting)
-    site = generate_class_instance(Site, seed=1, site_id=1, aggregator_id=aggregator_id)
+    der = generate_class_instance(SiteDER, seed=seed, site_id=None, site_der_setting=der_setting)
+    site = generate_class_instance(Site, seed=seed, aggregator_id=aggregator_id)
     site.site_ders = [der]
     return site
+
+
+def _make_archive_doe(
+    site_id: int,
+    group_id: int,
+    doe_id: int,
+    start: datetime,
+    duration_seconds: int,
+    *,
+    export_limit: Decimal | None = None,
+    import_limit: Decimal | None = None,
+    ramp_time_seconds: Decimal | None = None,
+    superseded: bool = False,
+    archive_time: datetime | None = None,
+    deleted_time: datetime | None = None,
+    seed: int = 1,
+) -> ArchiveDynamicOperatingEnvelope:
+    end = start + timedelta(seconds=duration_seconds)
+    return generate_class_instance(
+        ArchiveDynamicOperatingEnvelope,
+        seed=seed,
+        archive_id=None,
+        dynamic_operating_envelope_id=doe_id,
+        site_id=site_id,
+        site_control_group_id=group_id,
+        calculation_log_id=None,
+        start_time=start,
+        end_time=end,
+        duration_seconds=duration_seconds,
+        created_time=start - timedelta(seconds=30),
+        changed_time=start - timedelta(seconds=30),
+        export_limit_watts=export_limit,
+        import_limit_active_watts=import_limit,
+        generation_limit_active_watts=None,
+        load_limit_active_watts=None,
+        ramp_time_seconds=ramp_time_seconds,
+        set_connected=None,
+        set_energized=None,
+        superseded=superseded,
+        set_point_percentage=None,
+        randomize_start_seconds=None,
+        display_id=None,
+        archive_time=archive_time,
+        deleted_time=deleted_time,
+    )
+
+
+def _make_subscription(
+    group_id: int | None, *, resource_type: SubscriptionResource = SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE
+) -> Subscription:
+    sub = Subscription()
+    sub.aggregator_id = 1
+    sub.changed_time = T0
+    sub.resource_type = resource_type
+    sub.resource_id = group_id
+    sub.scoped_site_id = None
+    sub.notification_uri = "https://example.com/notify"
+    sub.entity_limit = 100
+    return sub
+
+
+# ─── _get_der_setting ─────────────────────────────────────────────────────────
+
+
+async def test_get_der_setting_no_site(pg_envoy_base_config):
+    """Returns None when no sites exist in the DB."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_der_setting(session)
+    assert result is None
+
+
+async def test_get_der_setting_no_der_setting(pg_envoy_base_config):
+    """Returns None when a site exists but has no SiteDER/SiteDERSetting attached."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        site = generate_class_instance(Site, seed=1, aggregator_id=1)
+        site.site_ders = []
+        session.add(site)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_der_setting(session)
+
+    assert result is None
+
+
+async def test_get_der_setting_returns_max_w_fields(pg_envoy_base_config):
+    """Returns the correct max_w_value and max_w_multiplier from the active site's DER setting."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        site = _make_site_with_setting(aggregator_id=1, max_w=7500)
+        session.add(site)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_der_setting(session)
+
+    assert result is not None
+    assert result.max_w_value == 7500
+    assert result.max_w_multiplier == 0
+
+
+async def test_get_der_setting_uses_most_recently_changed_site(pg_envoy_base_config):
+    """When multiple sites exist, returns the DER setting belonging to the site with the latest changed_time."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        old_site = _make_site_with_setting(aggregator_id=1, max_w=1000, seed=1)
+        old_site.changed_time = T0 - timedelta(hours=2)
+        session.add(old_site)
+        await session.flush()
+
+        new_site = _make_site_with_setting(aggregator_id=1, max_w=9000, seed=2)
+        new_site.changed_time = T0 - timedelta(hours=1)
+        session.add(new_site)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_der_setting(session)
+
+    assert result is not None
+    assert result.max_w_value == 9000
+
+
+# ─── _get_control_groups ──────────────────────────────────────────────────────
+
+
+async def test_get_control_groups_empty(pg_envoy_base_config):
+    """Returns an empty list when no SiteControlGroups exist."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_control_groups(session)
+    assert result == []
+
+
+async def test_get_control_groups_returns_all_with_correct_fields(pg_envoy_base_config):
+    """Returns all groups with the correct site_control_group_id and primacy values."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=10)
+        grp2 = generate_class_instance(SiteControlGroup, seed=2, site_control_group_id=2, primacy=20)
+        session.add_all([grp1, grp2])
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_control_groups(session)
+
+    assert len(result) == 2
+    by_id = {g.site_control_group_id: g for g in result}
+    assert by_id[1].primacy == 10
+    assert by_id[2].primacy == 20
+
+
+# ─── _get_subscribed_group_ids ────────────────────────────────────────────────
+
+
+async def test_get_subscribed_group_ids_empty(pg_envoy_base_config):
+    """Returns an empty set when no subscriptions exist."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_subscribed_group_ids(session)
+    assert result == set()
+
+
+async def test_get_subscribed_group_ids_returns_doe_resource_ids(pg_envoy_base_config):
+    """Returns the resource_ids for DOE subscriptions that have a non-null resource_id."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        session.add(_make_subscription(group_id=1))
+        session.add(_make_subscription(group_id=2))
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_subscribed_group_ids(session)
+
+    assert result == {1, 2}
+
+
+async def test_get_subscribed_group_ids_excludes_null_resource_id(pg_envoy_base_config):
+    """DOE subscriptions with resource_id=None (subscribe-all) are excluded."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        session.add(_make_subscription(group_id=5))
+        session.add(_make_subscription(group_id=None))  # subscribe-all, no specific group
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_subscribed_group_ids(session)
+
+    assert result == {5}
+
+
+async def test_get_subscribed_group_ids_excludes_non_doe_subscriptions(pg_envoy_base_config):
+    """Non-DOE subscription types are not included even when they have a resource_id."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        session.add(_make_subscription(group_id=7))
+        session.add(_make_subscription(group_id=99, resource_type=SubscriptionResource.SITE))
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_subscribed_group_ids(session)
+
+    assert result == {7}
+
+
+# ─── _get_does ────────────────────────────────────────────────────────────────
+
+
+async def test_get_does_empty(pg_envoy_base_config):
+    """Returns an empty list when no DOEs exist."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_does(session)
+    assert result == []
+
+
+@pytest.mark.parametrize("seed, optional_is_none", product([101, 202], [True, False]))
+async def test_get_does_active_doe_fields(pg_envoy_base_config, seed: int, optional_is_none: bool):
+    """Active DOE rows are returned with is_archive=False and correct field values."""
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        site = _make_site_with_setting(aggregator_id=1)
+        session.add(site)
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
+        session.add(grp)
+        doe = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=seed,
+            optional_is_none=optional_is_none,
+            site=site,
+            site_control_group=grp,
+            calculation_log_id=None,
+        )
+        session.add(doe)
+        await session.flush()
+
+        original_doe = clone_class_instance(doe)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_does(session)
+
+    assert len(result) == 1
+    row = result[0]
+    assert_class_instance_equality(
+        _RawDOE, original_doe, row, ignored_properties={"is_archive", "deleted_time", "archive_time"}
+    )
+    assert row.is_archive is False
+    assert row.deleted_time is None
+    assert row.archive_time is None
+
+
+@pytest.mark.parametrize("seed, optional_is_none", product([101, 202], [True, False]))
+async def test_get_does_archive_doe_fields(pg_envoy_base_config, seed: int, optional_is_none: bool):
+    """Archive DOE rows are returned with is_archive=True and correct field values."""
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        site = _make_site_with_setting(aggregator_id=1)
+        session.add(site)
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
+        session.add(grp)
+        archive_doe = generate_class_instance(
+            ArchiveDynamicOperatingEnvelope,
+            seed=seed,
+            optional_is_none=optional_is_none,
+            calculation_log_id=None,
+            site_id=site.site_id,
+            site_control_group_id=grp.site_control_group_id,
+        )
+        session.add(archive_doe)
+        await session.flush()
+
+        original__archive_doe = clone_class_instance(archive_doe)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_does(session)
+
+    assert len(result) == 1
+    row = result[0]
+    assert_class_instance_equality(_RawDOE, original__archive_doe, row, ignored_properties={"is_archive"})
+    assert row.is_archive is True
+
+
+async def test_get_does_combines_active_and_archive(pg_envoy_base_config):
+    """Both active and archive DOEs are returned together; is_archive distinguishes them."""
+    doe_start = T0 + timedelta(minutes=5)
+    duration = 300
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        site = _make_site_with_setting(aggregator_id=1)
+        session.add(site)
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
+        session.add(grp)
+        active_doe = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=2,
+            site=site,
+            site_control_group=grp,
+            calculation_log_id=None,
+            start_time=doe_start,
+            end_time=doe_start + timedelta(seconds=duration),
+            duration_seconds=duration,
+            created_time=doe_start - timedelta(seconds=30),
+            changed_time=doe_start - timedelta(seconds=30),
+            export_limit_watts=Decimal("2000"),
+            import_limit_active_watts=None,
+            generation_limit_active_watts=None,
+            load_limit_active_watts=None,
+            ramp_time_seconds=None,
+            set_connected=None,
+            superseded=False,
+            set_energized=None,
+            set_point_percentage=None,
+            randomize_start_seconds=None,
+        )
+        session.add(active_doe)
+        await session.flush()
+        site_id = site.site_id
+
+        archive_doe = _make_archive_doe(
+            site_id=site_id,
+            group_id=1,
+            doe_id=999,
+            start=doe_start + timedelta(minutes=10),
+            duration_seconds=300,
+            export_limit=Decimal("8000"),
+            archive_time=doe_start + timedelta(minutes=15),
+            seed=3,
+        )
+        session.add(archive_doe)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_does(session)
+
+    assert len(result) == 2
+    archive_flags = {row.dynamic_operating_envelope_id: row.is_archive for row in result}
+    active_id = next(r.dynamic_operating_envelope_id for r in result if not r.is_archive)
+    assert archive_flags[active_id] is False
+    assert archive_flags[999] is True
+
+
+async def test_get_does_scoped_to_active_site(pg_envoy_base_config):
+    """Only DOEs belonging to the most-recently-changed site are returned."""
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        # Older site — its DOEs should NOT be returned
+        old_site = _make_site_with_setting(aggregator_id=1, seed=1)
+        old_site.changed_time = T0 - timedelta(hours=2)
+        session.add(old_site)
+
+        # Newer site — the "active" site whose DOEs should be returned
+        new_site = _make_site_with_setting(aggregator_id=1, seed=2)
+        new_site.changed_time = T0 - timedelta(hours=1)
+        session.add(new_site)
+
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
+        session.add(grp)
+        await session.flush()
+
+        old_doe = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=11,
+            site=old_site,
+            site_control_group=grp,
+            calculation_log_id=None,
+            export_limit_watts=Decimal("1111"),
+        )
+        new_doe = generate_class_instance(
+            DynamicOperatingEnvelope,
+            seed=22,
+            site=new_site,
+            site_control_group=grp,
+            calculation_log_id=None,
+            export_limit_watts=Decimal("9999"),
+        )
+        session.add_all([old_doe, new_doe])
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_does(session)
+
+    assert len(result) == 1
+    assert result[0].export_limit_watts == pytest.approx(9999.0)
+
+
+# ─── _get_defaults ────────────────────────────────────────────────────────────
+
+
+async def test_get_defaults_empty(pg_envoy_base_config):
+    """Returns an empty list when no SiteControlGroupDefaults exist."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_defaults(session)
+    assert result == []
+
+
+@pytest.mark.parametrize("seed, optional_is_none", product([101, 202], [True, False]))
+async def test_get_defaults_active_default_fields(pg_envoy_base_config, seed: int, optional_is_none: bool):
+    """Active default rows are returned with is_archive=False and correct field values."""
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=3, primacy=1)
+        session.add(grp)
+        default = generate_class_instance(
+            SiteControlGroupDefault, seed=seed, optional_is_none=optional_is_none, site_control_group=grp
+        )
+        session.add(default)
+
+        original_default = clone_class_instance(default)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_defaults(session)
+
+    assert len(result) == 1
+    row = result[0]
+
+    assert_class_instance_equality(
+        _RawDefault, original_default, row, ignored_properties={"is_archive", "archive_time"}
+    )
+    assert row.is_archive is False
+    assert row.archive_time is None
+
+
+@pytest.mark.parametrize("seed, optional_is_none", product([101, 202], [True, False]))
+async def test_get_defaults_archive_default_fields(pg_envoy_base_config, seed: int, optional_is_none: bool):
+    """Archive default rows are returned with is_archive=True and archive_time populated."""
+
+    archive_time = datetime(2022, 11, 14, tzinfo=UTC)
+    async with generate_async_session(pg_envoy_base_config) as session:
+        archive_default = generate_class_instance(
+            ArchiveSiteControlGroupDefault, seed=seed, optional_is_none=optional_is_none, archive_time=archive_time
+        )
+        session.add(archive_default)
+
+        original_archive_default = clone_class_instance(archive_default)
+
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_defaults(session)
+
+    assert len(result) == 1
+    row = result[0]
+    assert_class_instance_equality(_RawDefault, original_archive_default, row, ignored_properties={"is_archive"})
+    assert row.is_archive is True
+
+
+async def test_get_defaults_combines_active_and_archive(pg_envoy_base_config):
+    """Both active and archive defaults are returned together; is_archive distinguishes them."""
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        grp = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
+        session.add(grp)
+        active_default = generate_class_instance(
+            SiteControlGroupDefault,
+            seed=1,
+            site_control_group=grp,
+            export_limit_active_watts=Decimal("5000"),
+        )
+        session.add(active_default)
+
+        archive_default = generate_class_instance(
+            ArchiveSiteControlGroupDefault,
+            seed=2,
+            site_control_group_id=2,
+            export_limit_active_watts=Decimal("7000"),
+        )
+        session.add(archive_default)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_defaults(session)
+
+    assert len(result) == 2
+    by_group = {r.site_control_group_id: r for r in result}
+    assert by_group[1].is_archive is False
+    assert by_group[1].export_limit_active_watts == pytest.approx(5000.0)
+    assert by_group[2].is_archive is True
+    assert by_group[2].export_limit_active_watts == pytest.approx(7000.0)
+
+
+async def test_get_defaults_not_scoped_to_site(pg_envoy_base_config):
+    """Defaults are returned regardless of which site is active (no site scoping)."""
+    async with generate_async_session(pg_envoy_base_config) as session:
+        # No site in the DB — yet defaults should still be returned
+        archive_default = generate_class_instance(
+            ArchiveSiteControlGroupDefault,
+            site_control_group_id=42,
+            export_limit_active_watts=Decimal("1234"),
+        )
+        session.add(archive_default)
+        await session.commit()
+
+    async with generate_async_session(pg_envoy_base_config) as session:
+        result = await _get_defaults(session)
+
+    assert len(result) == 1
+    assert result[0].site_control_group_id == 42
 
 
 # ─── Scenario A: Single program, export curtailment steps with AS4777 ramps ──
 
 
-@pytest.mark.anyio
 async def test_chart_single_program_export_curtailment(pg_envoy_base_config):
     """
     One DERProgram (primacy 1). Export is stepped down and back up over 40 minutes.
@@ -127,7 +628,7 @@ async def test_chart_single_program_export_curtailment(pg_envoy_base_config):
     created_times: list[datetime] = []
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         group = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         session.add(group)
@@ -157,7 +658,6 @@ async def test_chart_single_program_export_curtailment(pg_envoy_base_config):
 # ─── Scenario B: Two programs, primacy resolution, import + export limits ─────
 
 
-@pytest.mark.anyio
 async def test_chart_multi_program_primacy(pg_envoy_base_config):
     """
     Two DERPrograms operating simultaneously on different limit types:
@@ -172,7 +672,7 @@ async def test_chart_multi_program_primacy(pg_envoy_base_config):
     created_times: dict[str, datetime] = {}
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         grp2 = generate_class_instance(SiteControlGroup, seed=2, site_control_group_id=2, primacy=2)
@@ -215,7 +715,6 @@ async def test_chart_multi_program_primacy(pg_envoy_base_config):
 # ─── Scenario C: rampTms on controls, default control as baseline ─────────────
 
 
-@pytest.mark.anyio
 async def test_chart_ramptms_and_defaults(pg_envoy_base_config):
     """
     Demonstrates rampTms (explicit 120s ramp) and a default control baseline.
@@ -236,7 +735,7 @@ async def test_chart_ramptms_and_defaults(pg_envoy_base_config):
     created_times: dict[str, datetime] = {}
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         session.add(grp1)
@@ -291,7 +790,6 @@ async def test_chart_ramptms_and_defaults(pg_envoy_base_config):
 # ─── Scenario D: opModConnect disconnect and reconnect grace period ───────────
 
 
-@pytest.mark.anyio
 async def test_chart_op_mod_connect(pg_envoy_base_config):
     """
     Demonstrates opModConnect=False disconnect (power=0) and 1-minute grace after explicit
@@ -313,7 +811,7 @@ async def test_chart_op_mod_connect(pg_envoy_base_config):
     created_times: dict[str, datetime] = {}
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         session.add(grp1)
@@ -363,7 +861,6 @@ async def test_chart_op_mod_connect(pg_envoy_base_config):
 # ─── Scenario D2: opModConnect — expiry-triggered reconnect, no True control ──
 
 
-@pytest.mark.anyio
 async def test_chart_op_mod_connect_expiry(pg_envoy_base_config):
     """
     opModConnect=False control expires with no subsequent True control.
@@ -384,7 +881,7 @@ async def test_chart_op_mod_connect_expiry(pg_envoy_base_config):
     created_times: dict[str, datetime] = {}
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         session.add(grp1)
@@ -432,7 +929,6 @@ async def test_chart_op_mod_connect_expiry(pg_envoy_base_config):
 # ─── Scenario E: GEN-10 DERC4/5/6 — opModConnect + primacy + supersede ────────
 
 
-@pytest.mark.anyio
 async def test_chart_gen10_derc456(pg_envoy_base_config):
     """
     Approximates the GEN-10 DERC4/5/6 phase (primacy validation for generators).
@@ -472,7 +968,7 @@ async def test_chart_gen10_derc456(pg_envoy_base_config):
     test_end = T0 + timedelta(minutes=20)
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1, max_w=10000, grad_w=200)
+        site = _make_site_with_setting(aggregator_id=1, max_w=10000, grad_w=200)
         session.add(site)
         # Group 1 = FSA1 / DERP1, high priority. No export default → group 2 can win after DERC4.
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
@@ -525,7 +1021,6 @@ async def test_chart_gen10_derc456(pg_envoy_base_config):
 # ─── Scenario E2: GEN-10 DERC4/5/6 — subscription variant (no gap) ───────────
 
 
-@pytest.mark.anyio
 async def test_chart_gen10_derc456_subscribed(pg_envoy_base_config):
     """
     Subscription variant of test_chart_gen10_derc456.
@@ -554,7 +1049,7 @@ async def test_chart_gen10_derc456_subscribed(pg_envoy_base_config):
     test_end = T0 + timedelta(minutes=20)
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1, max_w=10000, grad_w=200)
+        site = _make_site_with_setting(aggregator_id=1, max_w=10000, grad_w=200)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         grp2 = generate_class_instance(SiteControlGroup, seed=2, site_control_group_id=2, primacy=2)
@@ -568,18 +1063,7 @@ async def test_chart_gen10_derc456_subscribed(pg_envoy_base_config):
         session.add_all([derc4, derc5, derc6])
 
         # Both groups subscribed — receipt = created_time for all controls
-        def _make_sub(resource_id: int) -> Subscription:
-            sub = Subscription()
-            sub.aggregator_id = 1
-            sub.changed_time = T0
-            sub.resource_type = SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE
-            sub.resource_id = resource_id
-            sub.scoped_site_id = None
-            sub.notification_uri = "https://example.com/notify"
-            sub.entity_limit = 100
-            return sub
-
-        session.add_all([_make_sub(1), _make_sub(2)])
+        session.add_all([_make_subscription(1), _make_subscription(2)])
 
         await session.flush()
         ct4, ct6 = derc4.created_time, derc6.created_time
@@ -612,7 +1096,6 @@ async def test_chart_gen10_derc456_subscribed(pg_envoy_base_config):
 # ─── Scenario F: opModEnergise — de-energise and re-energise grace period ─────
 
 
-@pytest.mark.anyio
 async def test_chart_op_mod_energise(pg_envoy_base_config):
     """
     Demonstrates opModEnergise=False de-energise (power=0) and 1-minute grace after
@@ -634,7 +1117,7 @@ async def test_chart_op_mod_energise(pg_envoy_base_config):
     created_times: dict[str, datetime] = {}
 
     async with generate_async_session(pg_envoy_base_config) as session:
-        site = _make_der_site(aggregator_id=1)
+        site = _make_site_with_setting(aggregator_id=1)
         session.add(site)
         grp1 = generate_class_instance(SiteControlGroup, seed=1, site_control_group_id=1, primacy=1)
         session.add(grp1)


### PR DESCRIPTION
Decouples the active power charts from the envoy DB schema (now will work with older schemas so long as the REQUIRED columns still exist)