### PR TITLE
Local dev runner ports

### DIFF
--- a/local-dev/.gitignore
+++ b/local-dev/.gitignore
@@ -1,0 +1,2 @@
+orchestrator.env
+pki/

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -1,0 +1,149 @@
+# Local development — orchestrator + UI from source
+
+Run `cactus-orchestrator` and `cactus-ui` as plain host processes with live reload, IDE breakpoints, real podman pods. 
+No traefik, nginx, or client-notifications included.
+
+Setting `DEV_RUNNER_LOCALHOST_PORT_BASE` makes orchestrator publish pod's on `127.0.0.1` port and hit it via localhost 
+instead of pod-name DNS (which only works inside `cactus-net`). **Never set this in production!!**
+
+This runs as non root to keep vscode debugger happy.
+
+Assumes Ubuntu 24.04 (or any Linux with rootful podman ≥ 4.9 on netavark).
+
+## 1. Podman, network, socket access
+
+```bash
+sudo apt install -y podman
+sudo systemctl enable --now podman.socket
+
+# Pod DNS requires netavark. Fresh 24.04 defaults to it; a box upgraded from 22.04 can be
+# stuck on cni — if so:
+# printf '[network]\nnetwork_backend = "netavark"\n' | sudo tee /etc/containers/containers.conf.d/netavark.conf
+podman info --format '{{.Host.NetworkBackend}}'        # must say: netavark
+
+sudo podman network create cactus-net                  # skip if it exists
+sudo podman network inspect cactus-net --format 'dns={{.DNSEnabled}}'   # must say: dns=true
+
+# Let your user talk to the rootful socket. Resets on reboot — re-run if you get "permission denied".
+sudo chmod 755 /run/podman && sudo chmod 666 /run/podman/podman.sock
+podman --url unix:///run/podman/podman.sock version    # verify, as your normal user
+```
+
+Optional, to survive reboots instead of re-running the chmods:
+
+```bash
+sudo mkdir -p /etc/systemd/system/podman.socket.d
+printf '[Socket]\nSocketMode=0666\nDirectoryMode=0755\n' | \
+    sudo tee /etc/systemd/system/podman.socket.d/local-dev.conf
+sudo systemctl daemon-reload && sudo systemctl restart podman.socket
+```
+
+(Restarting `podman.socket` invalidates the old socket handle — if a traefik container is
+running against it, `sudo podman rm -f traefik` so it gets recreated.)
+
+## 2. Postgres on the host
+
+Host postgres (not a container) so restoring dumps from the test server is easy.
+
+```bash
+sudo apt install -y postgresql
+sudo -u postgres psql -c "CREATE ROLE cactus LOGIN PASSWORD 'cactus'" -c "CREATE DATABASE cactusorchestrator OWNER cactus"
+PGPASSWORD=cactus psql -h 127.0.0.1 -U cactus -d cactusorchestrator -c "select 1"   # verify
+
+# Load real data later:
+#   ssh test-server pg_dump -Fc ... > dump && pg_restore -h 127.0.0.1 -U cactus -d cactusorchestrator dump
+```
+
+## 3. Throwaway PKI
+
+The orchestrator requires signing-chain files at startup. Generate dev-only certs:
+
+```bash
+uv run python local-dev/generate_dev_pki.py            # from the repo root
+```
+
+`--fqdn` defaults to `cactus.local.test` — must match `CACTUS_FQDN` in your env file.
+
+## 4. Teststack images
+
+The pull images we need (check cactus-deploy versions.lock for the latest names):
+
+```bash
+sudo podman pull cactusimageregistry.azurecr.io/cactus-db:174-v12
+sudo podman pull cactusimageregistry.azurecr.io/cactus-envoy:174-v12
+sudo podman pull cactusimageregistry.azurecr.io/cactus-runner:174-v12
+```
+
+## 5. Orchestrator — migrate, run, debug
+
+```bash
+cp local-dev/sample.env local-dev/orchestrator.env
+# edit orchestrator.env: 
+# JWTAUTH_* (Auth0 dev tenant, from the dev server's cactus.env),
+# CERT_* path prefixes,
+# image tags to match §4
+```
+
+From the repo root:
+
+```bash
+uv sync --all-extras
+uv run --env-file local-dev/orchestrator.env alembic upgrade head
+uv run --env-file local-dev/orchestrator.env --with 'uvicorn==0.48.0' uvicorn --reload --port 8080 cactus_orchestrator.main:app
+```
+
+Sanity check: `curl -i http://127.0.0.1:8080/procedure` → **401**
+
+OR run same thing from your debugger:
+`module: uvicorn`, `args: ["--port", "8080", "cactus_orchestrator.main:app"]`
+`envFile: ${workspaceFolder}/local-dev/orchestrator.env`,
+interpreter `.venv`.
+
+## 6. UI
+
+Following `cactus-ui/README.md` ("Running locally") with: 
+CACTUS_ORCHESTRATOR_BASEURL="http://localhost:8080" and `AUTH0_*` dev-tenant creds. 
+
+`http://localhost:3000/callback` must be in the Auth0 Allowed Callback URLs.
+
+```bash
+uv run python src/cactus_ui/server.py   # Flask backend on :3000
+cd frontend && npm run dev              # Vite on :5173  - develop here
+```
+
+## 7. Simulating the DER client (curl / Postman)
+
+**A real DER client can't connect to this dev instance.** In production, nginx terminates mTLS and injects the client 
+cert into the `ssl-client-cert` header. Locally runner speaks plain HTTP on a localhost port, you supply that header.
+
+Find a pod's runner port:
+
+```bash
+sudo podman pod ps                      # pod name, e.g. run-42
+sudo podman inspect run-42-runner --format '{{.HostConfig.PortBindings}}'
+curl http://127.0.0.1:<port>/health
+```
+
+The runner's API is `/health`, `/status`, `/initialise`, `/start`, `/finalize`.
+Everything else (`/dcap`, `/edev`) proxies to envoy: On every proxied request set the header, using the run's client cert (download from the UI):
+
+```bash
+python3 -c "import urllib.parse; print(urllib.parse.quote(open('client.cert.pem').read()))"
+# curl http://127.0.0.1:<port>/dcap -H "ssl-client-cert: <url-encoded PEM>"
+```
+
+In Postman: set a collection-level `ssl-client-cert` header. No TLS client cert config needed.
+
+**Future state:** for true mTLS with a real client, the pods already carry traefik labels. Just need to spin up
+traefik plus nginx per cactus-deploy `server/`. That needs resolvable `rg-*.{CACTUS_FQDN}` DNS and full cert staging.
+
+## Limitations / gotchas
+
+- **`DEV_RUNNER_LOCALHOST_PORT_BASE` is local-dev-only — never set it in production.**
+- `IDLETEARDOWNTASK_ENABLE=false` (the sample default) is required only when another
+  orchestrator shares the podman host — the task destroys any cactus pod it can't find in
+  *its own* database. On a dedicated machine, set it true to auto-clean abandoned pods;
+  with it false, clean up manually: `sudo podman pod rm -f <name>`.
+- The `https://rg-....cactus.local.test` run URLs shown in the UI don't resolve — reach
+  runners via their localhost port (§7).
+- Socket permissions (§1) reset on reboot unless you added the systemd override.

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -119,18 +119,25 @@ cert into the `ssl-client-cert` header. Locally runner speaks plain HTTP on a lo
 Find a pod's runner port:
 
 ```bash
-sudo podman pod ps                      # pod name, e.g. run-42
-sudo podman inspect run-42-runner --format '{{.HostConfig.PortBindings}}'
-curl http://127.0.0.1:<port>/health
+sudo podman ps                          # PORTS column shows e.g. 127.0.0.1:20042->8080/tcp
+# or, per pod (bindings live on the pod's infra container, not the runner container):
+sudo podman pod inspect run-42 --format '{{.InfraConfig.PortBindings}}'
+curl -i http://127.0.0.1:<port>/health       # HTTP 200, empty body (503 = unhealthy)
 ```
 
 The runner's API is `/health`, `/status`, `/initialise`, `/start`, `/finalize`.
-Everything else (`/dcap`, `/edev`) proxies to envoy: On every proxied request set the header, using the run's client cert (download from the UI):
+Envoy is proxied under the `ENVOY_PREFIX` prefix (default `/envoy`, per orchestrator settings): `/envoy/dcap`,
+`/envoy/edev`, etc. On every proxied request set the `ssl-client-cert` header to the **url-encoded contents** of the
+run's cert (the `fullchain.pem` from the UI's cert download ZIP works as-is — the leaf is first and the LFDI
+computation only reads the first cert):
 
 ```bash
-python3 -c "import urllib.parse; print(urllib.parse.quote(open('client.cert.pem').read()))"
-# curl http://127.0.0.1:<port>/dcap -H "ssl-client-cert: <url-encoded PEM>"
+curl http://127.0.0.1:<port>/envoy/dcap \
+  -H "ssl-client-cert: $(python3 -c "import urllib.parse; print(urllib.parse.quote(open('fullchain.pem').read()))")"
 ```
+
+Proxied responses: 400 = no active test procedure (initialise/start a run first), 403 = cert doesn't match the
+run's registered cert, 200 = through to envoy.
 
 In Postman: set a collection-level `ssl-client-cert` header. No TLS client cert config needed.
 

--- a/local-dev/generate_dev_pki.py
+++ b/local-dev/generate_dev_pki.py
@@ -1,0 +1,86 @@
+"""Generates the throwaway local-dev PKI the orchestrator needs at startup - see README.md §3.
+
+Writes only the files referenced by the CERT_* vars in sample.env, in the same directory layout as the
+production tooling (cactus-deploy pki/create-cert.sh + stage-certs.sh) so the two stay recognisable:
+
+    pki/serca/serca.cert.pem
+    pki/device-chain/MCA.cert.pem  MICA.cert.pem  MICA.key.pem
+    pki/aggregator-chain/pca.cert.pem  ica.cert.pem  ica.key.pem
+    pki/envoy/envoy.fullchain.pem  envoy.key.pem
+
+Usage (from the repo root):  uv run python local-dev/generate_dev_pki.py [--fqdn cactus.local.test]
+"""
+
+import argparse
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from cactus_orchestrator.certificate.chains import build_ca_cert
+from cactus_orchestrator.certificate.create import generate_aggregator_certificate
+
+type CertKeyPair = tuple[x509.Certificate, ec.EllipticCurvePrivateKey]
+
+
+def _pem(cert: x509.Certificate) -> bytes:
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _key_pem(key: ec.EllipticCurvePrivateKey) -> bytes:
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--fqdn", default="cactus.local.test", help="must match CACTUS_FQDN in orchestrator.env")
+    parser.add_argument("--out", default=Path(__file__).parent / "pki", type=Path, help="output directory")
+    args = parser.parse_args()
+    out: Path = args.out
+
+    if (out / "serca" / "serca.cert.pem").exists():
+        raise SystemExit(f"{out} already contains a PKI - delete it first to regenerate")
+
+    def new_ca(common_name: str, path_length: int | None, issuer: CertKeyPair | None = None) -> CertKeyPair:
+        key = ec.generate_private_key(ec.SECP256R1())
+        return (build_ca_cert(common_name, key, path_length=path_length, issuer=issuer), key)
+
+    serca = new_ca("IEEE 2030.5 Root", path_length=None)
+    mca = new_ca("IEEE 2030.5 MCA", path_length=1, issuer=serca)
+    mica = new_ca("IEEE 2030.5 MICA", path_length=0, issuer=mca)
+    pca = new_ca("CACTUS Services PCA", path_length=1, issuer=serca)
+    agg_ica = new_ca("CACTUS Aggregator ICA", path_length=0, issuer=pca)
+    dnsp_ica = new_ca("CACTUS DNSP ICA", path_length=0, issuer=pca)
+
+    # Static wildcard envoy EE (the utility-server identity envoy presents on outbound notifications).
+    # Uses the services EE profile - same as the production dnsp chain.
+    envoy_key, envoy_cert = generate_aggregator_certificate(dnsp_ica[1], dnsp_ica[0], 0, "envoy", f"*.{args.fqdn}")
+
+    files: dict[str, bytes] = {
+        "serca/serca.cert.pem": _pem(serca[0]),
+        "device-chain/MCA.cert.pem": _pem(mca[0]),
+        "device-chain/MICA.cert.pem": _pem(mica[0]),
+        "device-chain/MICA.key.pem": _key_pem(mica[1]),
+        "aggregator-chain/pca.cert.pem": _pem(pca[0]),
+        "aggregator-chain/ica.cert.pem": _pem(agg_ica[0]),
+        "aggregator-chain/ica.key.pem": _key_pem(agg_ica[1]),
+        "envoy/envoy.fullchain.pem": _pem(envoy_cert) + _pem(dnsp_ica[0]) + _pem(pca[0]),
+        "envoy/envoy.key.pem": _key_pem(envoy_key),
+    }
+    for rel, content in files.items():
+        path = out / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        path.chmod(0o600 if rel.endswith("key.pem") else 0o644)
+        print(f"wrote {path}")
+
+    print(f"\nDone - SAN *.{args.fqdn}. Point the CERT_* vars in orchestrator.env at {out.resolve()}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/local-dev/sample.env
+++ b/local-dev/sample.env
@@ -18,9 +18,9 @@ JWTAUTH_ISSUER="https://TENANT.auth0.com/"
 # localhost instead of pod-name DNS, so the orchestrator can run as a plain host process.
 DEV_RUNNER_LOCALHOST_PORT_BASE=20000
 
-# The idle-teardown task destroys any teststack pod not tracked in ITS OWN database —
-# dangerous if this podman host also runs a real deployment. It also disables the image
-# pull task, hence the manual pulls in README §4.
+# The idle-teardown task destroys any cactus pod on the host it can't find in ITS OWN database.
+# false = safe if another orchestrator shares this podman host. On a dedicated machine, true is
+# fine and auto-cleans abandoned pods (note: also tears down pods idle > 2h).
 IDLETEARDOWNTASK_ENABLE=false
 
 # === PKI (host paths — README §3 generates these; adjust the prefix to your checkout) ===

--- a/local-dev/sample.env
+++ b/local-dev/sample.env
@@ -1,0 +1,41 @@
+# Orchestrator env for local development — copy to orchestrator.env (gitignored) and edit.
+# Load it with:  uv run --env-file local-dev/orchestrator.env ...
+
+ORCHESTRATOR_DATABASE_URL="postgresql+asyncpg://cactus:cactus@127.0.0.1:5432/cactusorchestrator"
+
+# Only used for cert SANs and the run URLs shown in the UI — nothing resolves it locally.
+CACTUS_FQDN="cactus.local.test"
+
+# === Auth0 — reuse the dev tenant ===
+# Copy from the dev server's cactus.env. For UI login, http://localhost:3000/callback
+# must be whitelisted in the Auth0 application settings.
+JWTAUTH_JWKS_URL="https://TENANT.auth0.com/.well-known/jwks.json"
+JWTAUTH_AUDIENCE="https://cactus.example.com/"
+JWTAUTH_ISSUER="https://TENANT.auth0.com/"
+
+# === LOCAL DEV MODE ===
+# Publishes each pod's runner on 127.0.0.1:<derived port> and addresses runners via
+# localhost instead of pod-name DNS, so the orchestrator can run as a plain host process.
+DEV_RUNNER_LOCALHOST_PORT_BASE=20000
+
+# The idle-teardown task destroys any teststack pod not tracked in ITS OWN database —
+# dangerous if this podman host also runs a real deployment. It also disables the image
+# pull task, hence the manual pulls in README §4.
+IDLETEARDOWNTASK_ENABLE=false
+
+# === PKI (host paths — README §3 generates these; adjust the prefix to your checkout) ===
+CERT_SERCA_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/serca/serca.cert.pem"
+CERT_DEVICE_MCA_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/device-chain/MCA.cert.pem"
+CERT_DEVICE_MICA_CRT_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/device-chain/MICA.cert.pem"
+CERT_DEVICE_MICA_KEY_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/device-chain/MICA.key.pem"
+CERT_AGG_PCA_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/aggregator-chain/pca.cert.pem"
+CERT_AGG_ICA_CRT_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/aggregator-chain/ica.cert.pem"
+CERT_AGG_ICA_KEY_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/aggregator-chain/ica.key.pem"
+CERT_ENVOY_EE_FULLCHAIN_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/envoy/envoy.fullchain.pem"
+CERT_ENVOY_EE_KEY_PATH="/home/ubuntu/code/cactus-orchestrator/local-dev/pki/envoy/envoy.key.pem"
+
+# === Teststack images (see README §4; must exist locally — the orchestrator won't pull) ===
+CACTUS_IMAGE__V1_2__CSIP_AUS_VERSION="v1.2"
+CACTUS_IMAGE__V1_2__DB="cactusimageregistry.azurecr.io/cactus-db:174-v12"
+CACTUS_IMAGE__V1_2__ENVOY="cactusimageregistry.azurecr.io/cactus-envoy:174-v12"
+CACTUS_IMAGE__V1_2__RUNNER="cactusimageregistry.azurecr.io/cactus-runner:174-v12"

--- a/src/cactus_orchestrator/api/run.py
+++ b/src/cactus_orchestrator/api/run.py
@@ -159,6 +159,7 @@ async def get_group_runs_paginated(
                     PodResources.from_run(settings.podman_network, run),
                     run_group,
                     run,
+                    dev_localhost_port_base=settings.dev_runner_localhost_port_base,
                 ),
             )
             for run in runs
@@ -273,6 +274,7 @@ async def spawn_teststack_and_init_run(  # noqa: C901
         pod_resources,
         run_group,
         first_run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
 
     # Global static utility-server (envoy / DNSP) notification mTLS material - envoy presents this when POSTing
@@ -434,7 +436,13 @@ async def start_run(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
 
     # request runner starts run
@@ -561,7 +569,13 @@ async def get_individual_run(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
 
     # Fetch playlist_runs if this is a playlist run
@@ -630,7 +644,13 @@ async def finalise_run_and_teardown_teststack(  # noqa: C901
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
 
     # Don't attempt to cleanup / teardown if this has already been finalised
@@ -726,7 +746,13 @@ async def finalise_playlist(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
 
     # Finalize current test if it's active
@@ -864,7 +890,13 @@ async def get_run_status(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
     async with ClientSession(
         base_url=pod_routes.internal_base_url,
@@ -903,7 +935,13 @@ async def get_run_request_list(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
     async with ClientSession(
         base_url=pod_routes.internal_base_url,
@@ -944,7 +982,13 @@ async def get_run_request_data(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
     async with ClientSession(
         base_url=pod_routes.internal_base_url,
@@ -981,7 +1025,13 @@ async def proceed_proxy(
     settings = get_current_settings()
     pod_resources = PodResources.from_run(settings.podman_network, run)
     pod_routes = PodRoutes.from_run(
-        settings.cactus_fqdn, settings.envoy_prefix, settings.podman_runner_port, pod_resources, run_group, run
+        settings.cactus_fqdn,
+        settings.envoy_prefix,
+        settings.podman_runner_port,
+        pod_resources,
+        run_group,
+        run,
+        dev_localhost_port_base=settings.dev_runner_localhost_port_base,
     )
     async with ClientSession(
         base_url=pod_routes.internal_base_url,
@@ -1029,6 +1079,7 @@ async def get_run_list(
             pod_resources,
             run.run_group,
             run,
+            dev_localhost_port_base=settings.dev_runner_localhost_port_base,
         )
         run_responses.append(map_run_to_run_response(run, pod_routes))
 

--- a/src/cactus_orchestrator/certificate/chains.py
+++ b/src/cactus_orchestrator/certificate/chains.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime, timedelta
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from cactus_orchestrator.certificate.create import (
+    ORG_COUNTRY,
+    ORG_NAME,
+    calculate_rfc5280_subject_key_identifier_method_2,
+)
+
+# keyUsage asserted on every CA certificate, matching the NEPKI CA profile (cactus-deploy pki/create-cert.sh)
+CA_KEY_USAGE = x509.KeyUsage(
+    digital_signature=False,
+    content_commitment=False,
+    key_encipherment=False,
+    data_encipherment=False,
+    key_agreement=False,
+    key_cert_sign=True,
+    crl_sign=True,
+    encipher_only=False,
+    decipher_only=False,
+)
+
+
+def build_ca_cert(
+    common_name: str,
+    subject_key: ec.EllipticCurvePrivateKey,
+    path_length: int | None,
+    issuer: tuple[x509.Certificate, ec.EllipticCurvePrivateKey] | None = None,
+) -> x509.Certificate:
+    """Builds a CA certificate mirroring the structural NEPKI CA profile (cactus-deploy pki/create-cert.sh): a
+    C=AU,O=CACTUS,CN=<common_name> subject, critical CA basicConstraints with the supplied pathlen, keyCertSign+cRLSign
+    keyUsage and a method-2 subjectKeyIdentifier. issuer=None yields a self-signed root (SERCA); otherwise the cert is
+    signed by the issuer and carries the matching authorityKeyIdentifier.
+
+    NOT used to build production chains (that's cactus-deploy pki/create-cert.sh) - this exists for tests and the
+    local-dev throwaway PKI (local-dev/generate_dev_pki.py)."""
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, ORG_COUNTRY),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, ORG_NAME),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+    issuer_cert, signing_key = issuer if issuer is not None else (None, subject_key)
+    ski = x509.SubjectKeyIdentifier(calculate_rfc5280_subject_key_identifier_method_2(subject_key.public_key()))
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_cert.subject if issuer_cert is not None else subject)
+        .public_key(subject_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(UTC))
+        .not_valid_after(datetime.now(UTC) + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=path_length), critical=True)
+        .add_extension(CA_KEY_USAGE, critical=True)
+        .add_extension(ski, critical=False)
+    )
+    if issuer_cert is not None:
+        issuer_ski = issuer_cert.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
+        builder = builder.add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(issuer_ski.value), critical=False
+        )
+
+    return builder.sign(signing_key, hashes.SHA256())

--- a/src/cactus_orchestrator/pod/manager.py
+++ b/src/cactus_orchestrator/pod/manager.py
@@ -257,12 +257,18 @@ def _create_pod_and_containers(
     # a teststack breakout from being host-root. The pod owns the single shared namespace; every
     # member below must also pass userns_mode="auto" to join it — without it podman-py emits a
     # conflicting container-level id-mapping and the OCI runtime refuses the join.
-    client.pods.create(
-        name=resources.pod_name,
-        Networks={resources.shared_network_name: {}},
-        userns={"nsmode": "auto"},
-        labels=resources.pod_labels,
-    )
+    pod_create_kwargs: dict[str, Any] = {
+        "name": resources.pod_name,
+        "Networks": {resources.shared_network_name: {}},
+        "userns": {"nsmode": "auto"},
+        "labels": resources.pod_labels,
+    }
+    if routes.dev_host_port is not None:
+        # LOCAL DEV ONLY: also publish the runner on 127.0.0.1 so orchestrator can reach it
+        pod_create_kwargs["portmappings"] = [
+            {"host_ip": "127.0.0.1", "host_port": routes.dev_host_port, "container_port": routes.exposed_port}
+        ]
+    client.pods.create(**pod_create_kwargs)
     timings.append(("pod", time.monotonic() - t0))
 
     # 1. Postgres — binds localhost so other teststacks on cactus-net can't reach it

--- a/src/cactus_orchestrator/pod/models.py
+++ b/src/cactus_orchestrator/pod/models.py
@@ -1,7 +1,15 @@
+import zlib
 from dataclasses import dataclass
 from datetime import datetime
 
 from cactus_orchestrator.model import Run, RunGroup
+
+DEV_RUNNER_PORT_RANGE = 1000
+
+
+def dev_runner_localhost_port(port_base: int, pod_name: str) -> int:
+    """LOCAL DEV ONLY: derives a stable host port for a pod's runner from the pod name."""
+    return port_base + zlib.crc32(pod_name.encode()) % DEV_RUNNER_PORT_RANGE
 
 
 def generate_static_uri_external_host(cactus_fqdn: str, run_group_id: int) -> str:
@@ -33,20 +41,37 @@ class PodRoutes:
     internal_base_url: str  # For use from orchestrator -> runner pod.
     external_host: str
 
+    # LOCAL DEV ONLY: host port the runner is additionally published on
+    dev_host_port: int | None = None
+
     @staticmethod
     def from_run(
-        cactus_fqdn: str, envoy_href: str, exposed_port: int, resources: "PodResources", run_group: RunGroup, run: Run
+        cactus_fqdn: str,
+        envoy_href: str,
+        exposed_port: int,
+        resources: "PodResources",
+        run_group: RunGroup,
+        run: Run,
+        dev_localhost_port_base: int | None = None,
     ) -> "PodRoutes":
         if run_group.is_static_uri:
             external_host = generate_static_uri_external_host(cactus_fqdn, run.run_group_id)
         else:
             external_host = generate_dynamic_uri_external_host(cactus_fqdn, run.run_group_id, run.run_id)
 
+        if dev_localhost_port_base is not None:
+            dev_host_port = dev_runner_localhost_port(dev_localhost_port_base, resources.pod_name)
+            internal_base_url = f"http://127.0.0.1:{dev_host_port}"
+        else:
+            dev_host_port = None
+            internal_base_url = f"http://{resources.pod_name}:{exposed_port}"
+
         return PodRoutes(
             href_prefix=envoy_href,
             exposed_port=exposed_port,
-            internal_base_url=f"http://{resources.pod_name}:{exposed_port}",
+            internal_base_url=internal_base_url,
             external_host=external_host,
+            dev_host_port=dev_host_port,
         )
 
 

--- a/src/cactus_orchestrator/settings.py
+++ b/src/cactus_orchestrator/settings.py
@@ -100,6 +100,11 @@ class CactusOrchestratorSettings(BaseSettings):
     ignored_csip_aus_versions: list[str] = []
     ignored_test_procedures: list[str] = []
 
+    # LOCAL DEV ONLY - never set in production. When set, each pod's runner port is also published to
+    # 127.0.0.1:<port> on the host and the orchestrator addresses runners via localhost instead
+    # of pod-name DNS - allowing the orchestrator to run outside podman_network.
+    dev_runner_localhost_port_base: int | None = None
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/src/cactus_orchestrator/tasks.py
+++ b/src/cactus_orchestrator/tasks.py
@@ -95,6 +95,7 @@ async def destroy_idle_pods(
             pod_resources,
             run.run_group,
             run,
+            dev_localhost_port_base=settings.dev_runner_localhost_port_base,
         )
 
         idle = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,15 @@ from assertical.fixtures.environment import environment_snapshot
 from assertical.fixtures.fastapi import start_app_with_client
 from assertical.fixtures.postgres import generate_async_conn_str_from_connection
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from cryptography.x509.oid import NameOID
 from envoy.server.alembic import upgrade as envoy_upgrade
 from psycopg import Connection
 from sqlalchemy import NullPool, create_engine
 
 from cactus_orchestrator.auth import jwt_validator
+from cactus_orchestrator.certificate.chains import build_ca_cert
 from cactus_orchestrator.certificate.create import (
-    calculate_rfc5280_subject_key_identifier_method_2,
     generate_aggregator_certificate,
     generate_device_certificate,
 )
@@ -85,101 +84,46 @@ def pg_empty_config(postgresql, preserved_environment) -> Generator[Connection, 
     Base.metadata.drop_all(engine)
 
 
-# keyUsage asserted on every CA certificate, matching the NEPKI CA profile (cactus-deploy pki/create-cert.sh)
-_CA_KEY_USAGE = x509.KeyUsage(
-    digital_signature=False,
-    content_commitment=False,
-    key_encipherment=False,
-    data_encipherment=False,
-    key_agreement=False,
-    key_cert_sign=True,
-    crl_sign=True,
-    encipher_only=False,
-    decipher_only=False,
-)
-
-
-def _build_ca_cert(
-    common_name: str,
-    subject_key: ec.EllipticCurvePrivateKey,
-    path_length: int | None,
-    issuer: tuple[x509.Certificate, ec.EllipticCurvePrivateKey] | None = None,
-) -> x509.Certificate:
-    """Builds a CA certificate mirroring the structural NEPKI CA profile (cactus-deploy pki/create-cert.sh): a
-    C=AU,O=CACTUS,CN=<common_name> subject, critical CA basicConstraints with the supplied pathlen, keyCertSign+cRLSign
-    keyUsage and a method-2 subjectKeyIdentifier. issuer=None yields a self-signed root (SERCA); otherwise the cert is
-    signed by the issuer and carries the matching authorityKeyIdentifier."""
-    subject = x509.Name(
-        [
-            x509.NameAttribute(NameOID.COUNTRY_NAME, "AU"),
-            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "CACTUS"),
-            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
-        ]
-    )
-    issuer_cert, signing_key = issuer if issuer is not None else (None, subject_key)
-    ski = x509.SubjectKeyIdentifier(calculate_rfc5280_subject_key_identifier_method_2(subject_key.public_key()))
-
-    builder = (
-        x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer_cert.subject if issuer_cert is not None else subject)
-        .public_key(subject_key.public_key())
-        .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.now(UTC))
-        .not_valid_after(datetime.now(UTC) + timedelta(days=365))
-        .add_extension(x509.BasicConstraints(ca=True, path_length=path_length), critical=True)
-        .add_extension(_CA_KEY_USAGE, critical=True)
-        .add_extension(ski, critical=False)
-    )
-    if issuer_cert is not None:
-        issuer_ski = issuer_cert.extensions.get_extension_for_class(x509.SubjectKeyIdentifier)
-        builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier(issuer_ski.value), critical=False
-        )
-
-    return builder.sign(signing_key, hashes.SHA256())
-
-
 @pytest.fixture(scope="session")
 def serca_cert_key_pair() -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Shared self-signed root trust anchor (SERCA)."""
     serca_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("IEEE 2030.5 Root", serca_key, path_length=None), serca_key)
+    return (build_ca_cert("IEEE 2030.5 Root", serca_key, path_length=None), serca_key)
 
 
 @pytest.fixture(scope="session")
 def mca_cert_key_pair(serca_cert_key_pair) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Device chain level-2 CA (MCA), signed by SERCA."""
     mca_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("IEEE 2030.5 MCA", mca_key, path_length=1, issuer=serca_cert_key_pair), mca_key)
+    return (build_ca_cert("IEEE 2030.5 MCA", mca_key, path_length=1, issuer=serca_cert_key_pair), mca_key)
 
 
 @pytest.fixture(scope="session")
 def mica_cert_key_pair(mca_cert_key_pair) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Device chain level-3 CA (MICA), signs device EE certs."""
     mica_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("IEEE 2030.5 MICA", mica_key, path_length=0, issuer=mca_cert_key_pair), mica_key)
+    return (build_ca_cert("IEEE 2030.5 MICA", mica_key, path_length=0, issuer=mca_cert_key_pair), mica_key)
 
 
 @pytest.fixture(scope="session")
 def services_pca_cert_key_pair(serca_cert_key_pair) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Shared Services PCA, signed by SERCA - the common parent of the Aggregator and DNSP ICAs."""
     pca_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("CACTUS Services PCA", pca_key, path_length=1, issuer=serca_cert_key_pair), pca_key)
+    return (build_ca_cert("CACTUS Services PCA", pca_key, path_length=1, issuer=serca_cert_key_pair), pca_key)
 
 
 @pytest.fixture(scope="session")
 def agg_ica_cert_key_pair(services_pca_cert_key_pair) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Aggregator chain level-3 CA, signs aggregator EE certs."""
     ica_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("CACTUS Aggregator ICA", ica_key, path_length=0, issuer=services_pca_cert_key_pair), ica_key)
+    return (build_ca_cert("CACTUS Aggregator ICA", ica_key, path_length=0, issuer=services_pca_cert_key_pair), ica_key)
 
 
 @pytest.fixture(scope="session")
 def dnsp_ica_cert_key_pair(services_pca_cert_key_pair) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
     """Utility-server (DNSP) chain level-3 CA, signs the envoy EE cert."""
     ica_key: ec.EllipticCurvePrivateKey = ec.generate_private_key(ec.SECP256R1())
-    return (_build_ca_cert("CACTUS DNSP ICA", ica_key, path_length=0, issuer=services_pca_cert_key_pair), ica_key)
+    return (build_ca_cert("CACTUS DNSP ICA", ica_key, path_length=0, issuer=services_pca_cert_key_pair), ica_key)
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/pod/test_manager.py
+++ b/tests/unit/pod/test_manager.py
@@ -269,11 +269,15 @@ async def test_destroy_pod_resources(
         [{}, {"State": {"Health": {"Status": "not healthy"}}}, {"State": {"Health": {"Status": "hEALTHY"}}}],
     ],
 )
-async def test_create_pod_run_success(mock_client: MockedPodmanClient, health_values: list[dict]):
+@pytest.mark.parametrize("dev_host_port", [None, 12345])
+async def test_create_pod_run_success(
+    mock_client: MockedPodmanClient, health_values: list[dict], dev_host_port: int | None
+):
     """Does a successful startup behave as expected - and can handle health checks taking a bit to stabilise"""
     # Arrange
+    health_values = list(health_values)  # parametrize shares the list object and the test pops from it
     images = generate_class_instance(PodImages, seed=101)
-    routes = generate_class_instance(PodRoutes, seed=202)
+    routes = generate_class_instance(PodRoutes, seed=202, dev_host_port=dev_host_port)
     resources = generate_class_instance(PodResources, seed=303)
     pki = PodPKI(server_ca_bytes=b"ca", server_cert_bytes=b"cert", server_key_bytes=b"key")
 
@@ -312,9 +316,24 @@ async def test_create_pod_run_success(mock_client: MockedPodmanClient, health_va
 
     # We created a shared volume / pod
     mock_client.volumes_create.assert_called_once_with(name=resources.volume_name)
-    mock_client.pods_create.assert_has_calls(
-        [mock.call(name=resources.pod_name, Networks=mock.ANY, userns=mock.ANY, labels=resources.pod_labels)]
-    )
+    if dev_host_port is None:
+        mock_client.pods_create.assert_has_calls(
+            [mock.call(name=resources.pod_name, Networks=mock.ANY, userns=mock.ANY, labels=resources.pod_labels)]
+        )
+    else:
+        mock_client.pods_create.assert_has_calls(
+            [
+                mock.call(
+                    name=resources.pod_name,
+                    Networks=mock.ANY,
+                    userns=mock.ANY,
+                    labels=resources.pod_labels,
+                    portmappings=[
+                        {"host_ip": "127.0.0.1", "host_port": dev_host_port, "container_port": routes.exposed_port}
+                    ],
+                )
+            ]
+        )
 
     # Our containers are created - noting that we create via the low level API due to startup health checks
     assert mock_client.containers_run.call_count == 0

--- a/tests/unit/pod/test_models.py
+++ b/tests/unit/pod/test_models.py
@@ -1,0 +1,67 @@
+import pytest
+from assertical.fake.generator import generate_class_instance
+
+from cactus_orchestrator.model import Run, RunGroup
+from cactus_orchestrator.pod.models import DEV_RUNNER_PORT_RANGE, PodResources, PodRoutes, dev_runner_localhost_port
+
+
+@pytest.mark.parametrize("is_static_uri", [True, False])
+def test_from_run_without_dev_port_base_uses_pod_dns(is_static_uri: bool):
+    run = generate_class_instance(Run, run_id=11, run_group_id=22, pod_name=None)
+    run_group = generate_class_instance(RunGroup, is_static_uri=is_static_uri, certificate_pem=bytes([1]))
+    resources = PodResources.from_run("cactus-net", run)
+
+    routes = PodRoutes.from_run("cactus.example.com", "/envoy", 8080, resources, run_group, run)
+
+    assert routes.internal_base_url == "http://run-11:8080"
+    assert routes.dev_host_port is None
+
+
+@pytest.mark.parametrize("is_static_uri", [True, False])
+def test_from_run_with_dev_port_base_uses_localhost(is_static_uri: bool):
+    run = generate_class_instance(Run, run_id=11, run_group_id=22, pod_name=None)
+    run_group = generate_class_instance(RunGroup, is_static_uri=is_static_uri, certificate_pem=bytes([1]))
+    resources = PodResources.from_run("cactus-net", run)
+
+    routes = PodRoutes.from_run(
+        "cactus.example.com", "/envoy", 8080, resources, run_group, run, dev_localhost_port_base=20000
+    )
+
+    assert routes.dev_host_port is not None
+    assert 20000 <= routes.dev_host_port < 20000 + DEV_RUNNER_PORT_RANGE
+    assert routes.internal_base_url == f"http://127.0.0.1:{routes.dev_host_port}"
+
+    # Everything unrelated to runner addressing must be identical to the production path
+    prod_routes = PodRoutes.from_run("cactus.example.com", "/envoy", 8080, resources, run_group, run)
+    assert routes.external_host == prod_routes.external_host
+    assert routes.href_prefix == prod_routes.href_prefix
+    assert routes.exposed_port == prod_routes.exposed_port
+
+
+def test_dev_runner_localhost_port_deterministic_on_pod_name():
+    assert dev_runner_localhost_port(20000, "run-11") == dev_runner_localhost_port(20000, "run-11")
+    assert dev_runner_localhost_port(20000, "run-11") != dev_runner_localhost_port(20000, "run-12")
+
+    shared_pod_run_a = generate_class_instance(Run, seed=1, run_id=11, run_group_id=22, pod_name="shared-pod")
+    shared_pod_run_b = generate_class_instance(Run, seed=2, run_id=99, run_group_id=22, pod_name="shared-pod")
+    run_group = generate_class_instance(RunGroup, is_static_uri=True, certificate_pem=bytes([1]))
+
+    routes_a = PodRoutes.from_run(
+        "cactus.example.com",
+        "/envoy",
+        8080,
+        PodResources.from_run("cactus-net", shared_pod_run_a),
+        run_group,
+        shared_pod_run_a,
+        dev_localhost_port_base=20000,
+    )
+    routes_b = PodRoutes.from_run(
+        "cactus.example.com",
+        "/envoy",
+        8080,
+        PodResources.from_run("cactus-net", shared_pod_run_b),
+        run_group,
+        shared_pod_run_b,
+        dev_localhost_port_base=20000,
+    )
+    assert routes_a.internal_base_url == routes_b.internal_base_url

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -47,3 +47,12 @@ def test_parse_images_from_env(cleared_env):
     assert settings.images["v1.88-storage-beta"].db == "cactus-db:1"
     assert settings.images["v1.88-storage-beta"].envoy == "envoy:4"
     assert settings.images["v1.88-storage-beta"].runner == "runner"
+
+
+def test_dev_runner_localhost_port_base_defaults_off(cleared_env):
+    """Makes sure we dont accidentally deploy dev version somehow"""
+    assert "DEV_RUNNER_LOCALHOST_PORT_BASE" not in os.environ
+
+    settings = CactusOrchestratorSettings()  # ty:ignore[missing-argument]
+
+    assert settings.dev_runner_localhost_port_base is None


### PR DESCRIPTION
For local orchetstrator development, allow runner to use localhost, rather than needing to create cactus-net on traefic to get running. 

This lets people run orchestrator on thier local (with real podman and postgres) alongside cactus-ui. It will let curl requests work but to point real clients at it, more config will be needed (nginx).