### PR TITLE
save deploy tag in PDF

### DIFF
--- a/src/cactus_orchestrator/api/admin.py
+++ b/src/cactus_orchestrator/api/admin.py
@@ -51,6 +51,7 @@ from cactus_orchestrator.crud import (
     select_compliance_request,
     select_compliance_request_finalisation,
     select_compliance_requests,
+    select_deploy_release_at,
     select_group_runs_aggregated_by_procedure,
     select_group_runs_for_procedure,
     select_run_group_counts_for_user,
@@ -339,7 +340,12 @@ async def admin_regenerate_report_and_get_run_artifact(
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="RunArtifact has no reporting data.")
 
     try:
-        await regenerate_run_artifact(session=db.session, run_artifact=run.run_artifact)
+        deploy_release = await select_deploy_release_at(db.session, run.created_at)
+        await regenerate_run_artifact(
+            session=db.session,
+            run_artifact=run.run_artifact,
+            deploy_release_tag=deploy_release.release_tag if deploy_release else None,
+        )
     except ValueError as err:
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Unable to regenerate pdf run report"

--- a/src/cactus_orchestrator/api/run.py
+++ b/src/cactus_orchestrator/api/run.py
@@ -60,6 +60,7 @@ from cactus_orchestrator.crud import (
     delete_runs,
     insert_playlist_runs,
     insert_run_for_run_group,
+    select_deploy_release_at,
     select_next_playlist_run,
     select_passed_runs_for_user,
     select_playlist_runs,
@@ -106,10 +107,12 @@ async def get_run_artifact_response_for_user(user: User, run_id: int) -> Respons
             logger.warning(f"Run {run_id} artifact is missing a PDF and has no reporting data — cannot generate")
         else:
             try:
+                deploy_release = await select_deploy_release_at(db.session, run.created_at)
                 updated = await regenerate_pdf_report(
                     file_data=artifact.file_data,
                     raw_reporting_data=artifact.reporting_data,
                     version=artifact.version,
+                    deploy_release_tag=deploy_release.release_tag if deploy_release else None,
                 )
                 await update_runartifact_with_file_data(db.session, artifact, updated)
                 await db.session.commit()
@@ -533,8 +536,12 @@ async def finalise_run(
         if reporting_data:
             try:
                 reporting_data_version = json.loads(reporting_data)["version"]
+                deploy_release = await select_deploy_release_at(session, run.created_at)
                 file_data = await regenerate_pdf_report(
-                    file_data=file_data, raw_reporting_data=reporting_data, version=reporting_data_version
+                    file_data=file_data,
+                    raw_reporting_data=reporting_data,
+                    version=reporting_data_version,
+                    deploy_release_tag=deploy_release.release_tag if deploy_release else None,
                 )
             except Exception as exc:
                 msg = f"Unable to regenerate run report for run {run.run_id}. Reason={exc}"

--- a/src/cactus_orchestrator/artifact.py
+++ b/src/cactus_orchestrator/artifact.py
@@ -149,7 +149,12 @@ def _add_text_file_to_zip_data(zip_data: bytes, filename: str, content: str) -> 
     return zip_buffer.getvalue()
 
 
-async def regenerate_pdf_report(file_data: bytes, raw_reporting_data: str, version: int) -> bytes:
+async def regenerate_pdf_report(
+    file_data: bytes,
+    raw_reporting_data: str,
+    version: int,
+    deploy_release_tag: str | None = None,
+) -> bytes:
     """A pdf run report is generated from `reporting_data`, and replaces the existing
     pdf stored in the `file_data` zip.
 
@@ -162,6 +167,8 @@ async def regenerate_pdf_report(file_data: bytes, raw_reporting_data: str, versi
         file_data (bytes): a zip archive containing a pdf run report (to be replaced)
         raw_reporting_data (str): ReportingData as a json encoded string
         version (int): the version of the reporting data in `raw_reporting_data`.
+        deploy_release_tag (str | None): the cactus-deploy release tag that was live for this run's pod
+            (Run.deploy_release_tag).
     Returns:
         bytes: the updated zip file data.
     Raises:
@@ -179,7 +186,9 @@ async def regenerate_pdf_report(file_data: bytes, raw_reporting_data: str, versi
 
     try:
         if version == 1:
-            pdf_data = await generate_pdf_report_v1(reporting_data=reporting_data)
+            pdf_data = await generate_pdf_report_v1(
+                reporting_data=reporting_data, deploy_release_tag=deploy_release_tag
+            )
         else:
             raise ValueError(f"Unknown version of reporting data ({version})")
     except Exception as exc:
@@ -208,7 +217,9 @@ async def regenerate_pdf_report(file_data: bytes, raw_reporting_data: str, versi
     return updated_zip_data
 
 
-async def regenerate_run_artifact(session: AsyncSession, run_artifact: RunArtifact) -> RunArtifact:
+async def regenerate_run_artifact(
+    session: AsyncSession, run_artifact: RunArtifact, deploy_release_tag: str | None = None
+) -> RunArtifact:
     """Regenerates the RunArtifact.
 
     - Uses the reporting data to (re)generate the run report.
@@ -219,6 +230,8 @@ async def regenerate_run_artifact(session: AsyncSession, run_artifact: RunArtifa
     Args:
         session: A database session.
         run_artifact (RunArtifact): The RunArtifact to update.
+        deploy_release_tag (str | None): the cactus-deploy release tag that was live for this run's pod
+            (Run.deploy_release_tag).
     Returns:
         RunArtifact: the updated RunArtifact
     Raises:
@@ -230,6 +243,7 @@ async def regenerate_run_artifact(session: AsyncSession, run_artifact: RunArtifa
         file_data=run_artifact.file_data,
         raw_reporting_data=run_artifact.reporting_data,  # ty: ignore[invalid-argument-type]
         version=run_artifact.version,  # ty: ignore[invalid-argument-type]
+        deploy_release_tag=deploy_release_tag,
     )
 
     # Update the file data

--- a/src/cactus_orchestrator/crud.py
+++ b/src/cactus_orchestrator/crud.py
@@ -924,3 +924,13 @@ async def select_deploy_releases(session: AsyncSession, limit: int) -> Sequence[
     stmt = select(DeployRelease).order_by(DeployRelease.created_at.desc()).limit(limit)
     result = await session.execute(stmt)
     return result.scalars().all()
+
+
+async def select_deploy_release_at(session: AsyncSession, at: datetime) -> DeployRelease | None:
+    """Get the release that was live at a given point in time - the most recently deployed release with
+    created_at <= at. Returns None if `at` predates every recorded deploy (e.g. deploy_release wasn't tracked yet)."""
+    stmt = (
+        select(DeployRelease).where(DeployRelease.created_at <= at).order_by(DeployRelease.created_at.desc()).limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()

--- a/src/cactus_orchestrator/reporting/generate.py
+++ b/src/cactus_orchestrator/reporting/generate.py
@@ -9,7 +9,9 @@ from cactus_orchestrator.reporting.run_reporting import pdf_report_as_bytes
 logger = logging.getLogger(__name__)
 
 
-async def generate_pdf_report_v1(reporting_data: ReportingData_v1) -> bytes | None:
+async def generate_pdf_report_v1(
+    reporting_data: ReportingData_v1, deploy_release_tag: str | None = None
+) -> bytes | None:
 
     # Unpack the readings: time_period_start is serialised as epoch ms integers by to_json(), so we explicitly convert
     # it back to datetime; pd.read_json convert_dates heuristic doesn't match the column name and would leave it int64.
@@ -29,6 +31,7 @@ async def generate_pdf_report_v1(reporting_data: ReportingData_v1) -> bytes | No
         sites=reporting_data.sites,
         timeline=reporting_data.timeline,
         set_max_w_varied=reporting_data.set_max_w_varied,
+        deploy_release_tag=deploy_release_tag,
     )
 
     return pdf_data

--- a/src/cactus_orchestrator/reporting/run_reporting.py
+++ b/src/cactus_orchestrator/reporting/run_reporting.py
@@ -10,7 +10,6 @@ import pandas as pd
 import PIL.Image as PilImage
 import plotly.express as px
 import plotly.graph_objects as go
-from cactus_runner import __version__ as cactus_runner_version
 from cactus_runner.app.envoy_common import ReadingLocation
 from cactus_runner.app.timeline import Timeline, duration_to_label
 from cactus_runner.models import (
@@ -184,6 +183,7 @@ def first_page_template(
     test_procedure_name: str,
     test_run_id: str,
     csip_aus_version: CSIPAusVersion,
+    deploy_release_tag: str | None,
 ) -> None:
     """Template for the first/front/title page of the report"""
 
@@ -235,10 +235,12 @@ def first_page_template(
         PAGE_HEIGHT - BANNER_HEIGHT - 0.35 * inch,
         f"Cactus Test Definitions v{cactus_test_definitions_version}",
     )
+    # The deploy release tag reflects the cactus-deploy release that was actually live when this run's pod was
+    # created (recorded on Run at pod-creation)
     canvas.drawRightString(
         PAGE_WIDTH - MARGIN,
         PAGE_HEIGHT - BANNER_HEIGHT - 0.5 * inch,
-        f"Cactus Runner v{cactus_runner_version}",
+        f"Deploy Release {deploy_release_tag if deploy_release_tag is not None else 'unknown'}",
     )
     canvas.drawRightString(
         PAGE_WIDTH - MARGIN,
@@ -1786,6 +1788,7 @@ def pdf_report_as_bytes(
     reading_counts: dict[ReadingType, int],
     sites: list[Site],
     timeline: Timeline | None,
+    deploy_release_tag: str | None = None,
     no_spacers: bool = False,
     set_max_w_varied: bool = False,
 ) -> bytes:
@@ -1820,6 +1823,7 @@ def pdf_report_as_bytes(
         test_procedure_name=test_procedure_name,
         test_run_id=test_run_id,
         csip_aus_version=runner_state.active_test_procedure.csip_aus_version,
+        deploy_release_tag=deploy_release_tag,
     )
     later_pages = partial(
         later_pages_template,


### PR DESCRIPTION
Fixes bug where regenerating a PDF uses the latest cactus-orchestrator/runner versions rather than the ones used for the run. 